### PR TITLE
Use a single tokio runtime in the server

### DIFF
--- a/backend/server/src/client.rs
+++ b/backend/server/src/client.rs
@@ -34,7 +34,11 @@ pub async fn listen_for_client(socket: String) -> Result<()> {
     loop {
         match listener.accept().await {
             Ok((stream, _)) => {
-                tokio::spawn(async { handle_client(stream).await });
+                tokio::spawn(async {
+                    if let Err(err) = handle_client(stream).await {
+                        warn!("Failed to handle socket connection: {:?}", err);
+                    }
+                });
             }
             Err(err) => {
                 warn!("Failed to create socket connection: {:?}", err);

--- a/backend/server/src/main.rs
+++ b/backend/server/src/main.rs
@@ -9,7 +9,6 @@ use log::warn;
 use chrono::Local;
 use std::io::Write;
 use std::net::Ipv4Addr;
-use tokio::runtime::Runtime;
 use shared::dirs::eka_dirs;
 use crate::error::Result;
 
@@ -38,9 +37,7 @@ async fn main() -> Result<()> {
           .to_string()
     );
 
-    let rt = Runtime::new()?;
-
-    rt.spawn(async { client::listen_for_client(socket) });
+    tokio::spawn(async { client::listen_for_client(socket).await });
 
     if let Err(e) = github::register_app().await {
         warn!(target: &LOG_TARGET, "Failed to register as github app: {:?}", e);


### PR DESCRIPTION
See commit messages for details. TLDR this change is not necessary for correctness, but we avoids wasting resources.

I explicitly did not include unrelated rustfmt changes, I expect we will fix these separately at some point.