### PR TITLE
add dummy `/api/v1/logs/{drv}` handler

### DIFF
--- a/backend/server/src/web.rs
+++ b/backend/server/src/web.rs
@@ -36,7 +36,7 @@ impl WebService {
     }
 
     pub async fn run(self, spa_bundle_path: &SpaBundle) {
-        let app = Router::new().nest("/api", api_routes());
+        let app = Router::new().nest("/api/v1", api_routes());
 
         let app = if let SpaBundle::Path(spa_bundle_path) = spa_bundle_path {
             // If nothing else matched, always return the SPA. The client application has its own
@@ -59,8 +59,11 @@ impl WebService {
 }
 
 fn api_routes() -> Router {
-    // Placeholder to verify that nesting works as expected.
-    Router::new().route("/", get(|| async { "API" }))
+    Router::new().route("/logs/{drv}", get(get_derivation_log))
+}
+
+async fn get_derivation_log(axum::extract::Path(drv): axum::extract::Path<String>) -> String {
+    format!("Dummy log data for {drv}")
 }
 
 fn spa_service(bundle: &Path) -> ServeDir<SetStatus<ServeFile>> {


### PR DESCRIPTION
I don't really love having to do `axum::extract::Path` since `path::Path` is imported, but what can you do.
Closes #45
