### PR TITLE
add rustsec audit workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,15 @@
+name: RustSec security audit
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # daily
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          working-directory: backend


### PR DESCRIPTION
Adds a workflow to run [cargo-audit](https://github.com/rustsec/rustsec/tree/main/cargo-audit) daily to be notified of relevant CVEs.
Should probably fix the dependency on SQLx first though, since it is locked to a yanked version and is pulling in a vulnerable dependency. Will probably open a PR for that later
