### PR TITLE
Implement dev-server script

### DIFF
--- a/backend/server/src/web.rs
+++ b/backend/server/src/web.rs
@@ -36,7 +36,7 @@ impl WebService {
     }
 
     pub async fn run(self, spa_bundle_path: &SpaBundle) {
-        let app = Router::new().nest("/api/v1", api_routes());
+        let app = Router::new().nest("/v1", api_routes());
 
         let app = if let SpaBundle::Path(spa_bundle_path) = spa_bundle_path {
             // If nothing else matched, always return the SPA. The client application has its own

--- a/nix/dev-server.nix
+++ b/nix/dev-server.nix
@@ -1,11 +1,53 @@
-{ writeShellApplication }:
+{
+  git,
+  mktemp,
+  mprocs,
+  caddy,
+  cargo,
+  watchexec,
+  elmPackages,
+  live-server,
+  writeShellApplication,
+  writeText,
+}:
 
+let
+  caddyfile = writeText "config.caddyfile" ''
+    http://localhost:8080
+
+    handle_path /api/* {
+      reverse_proxy :3030
+    }
+
+    handle {
+      reverse_proxy :3031
+    }
+  '';
+
+in
 writeShellApplication {
   name = "dev-server";
 
-  runtimeInputs = [ ];
+  runtimeInputs = [
+    git
+    mktemp
+    mprocs
+    caddy
+    cargo
+    watchexec
+    elmPackages.elm
+    live-server
+  ];
 
   text = ''
-    echo "Hello, World!"
+    BASE_DIR=$(git rev-parse --show-toplevel)
+
+    TEMP=$(mktemp -d)
+
+    mprocs \
+      "XDG_DATA_HOME=$TEMP XDG_CONFIG_HOME=$TEMP caddy run --config ${caddyfile}" \
+      "XDG_RUNTIME_DIR=$TEMP cargo run --manifest-path $BASE_DIR/backend/server/Cargo.toml" \
+      "watchexec --watch $BASE_DIR/frontend/src --workdir $BASE_DIR/frontend --timings elm make src/Main.elm --output static/main.js" \
+      "live-server --port 3031 $BASE_DIR/frontend/static"
   '';
 }


### PR DESCRIPTION
Implement the `dev-server` script that runs Caddy as a reverse proxy to both the backend and a hot-reload server for the frontend.
This is a more minimal implementation of the latest work done in #56, I believe it behaves the same.
Two more pull requests should probably follow: removing the SPA bundle code from the backend, and implementing a similar script for production.
