### PR TITLE
add rust-analyzer to dev-shell

### DIFF
--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -7,6 +7,7 @@
   pkg-config,
   rustc,
   rustfmt,
+  rust-analyzer,
   dev-server,
 }:
 
@@ -17,6 +18,7 @@ mkShell {
     pkg-config
     rustc
     rustfmt
+    rust-analyzer
     elmPackages.elm
     elmPackages.elm-format
     dev-server


### PR DESCRIPTION
When using an LSP client, rust-analyzer's version should match rustc's version so it should be included in the devshell.
