### PR TITLE
Fix some dev-server UX issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 result*
-
 **/target/
+mprocs.log

--- a/nix/dev-server.nix
+++ b/nix/dev-server.nix
@@ -12,7 +12,7 @@
 }:
 
 let
-  caddyfile = writeText "config.caddyfile" ''
+  caddyConfig = writeText "config.caddyfile" ''
     http://localhost:8080
 
     handle_path /api/* {
@@ -42,12 +42,13 @@ writeShellApplication {
   text = ''
     BASE_DIR=$(git rev-parse --show-toplevel)
 
-    TEMP=$(mktemp -d)
+    XDG_RUNTIME_DIR=$(mktemp -d)
+    export XDG_RUNTIME_DIR
 
     mprocs \
-      "XDG_DATA_HOME=$TEMP XDG_CONFIG_HOME=$TEMP caddy run --config ${caddyfile}" \
-      "XDG_RUNTIME_DIR=$TEMP cargo run --manifest-path $BASE_DIR/backend/server/Cargo.toml" \
+      "cargo run --manifest-path $BASE_DIR/backend/server/Cargo.toml" \
       "watchexec --watch $BASE_DIR/frontend/src --workdir $BASE_DIR/frontend --timings elm make src/Main.elm --output static/main.js" \
-      "live-server --port 3031 $BASE_DIR/frontend/static"
+      "live-server --port 3031 $BASE_DIR/frontend/static" \
+      "caddy run --config ${caddyConfig}"
   '';
 }


### PR DESCRIPTION
- reordered mprocs processes to make `cargo` first, as it's the one you would most likely want to rerun.
- removed the explicit environment variables set for the processes as they show up mprocs and cause confusion. `XDG_RUNTIME_DIR` is now exported, and the variables set for caddy are only mildly useful when run in a pure devshell, which is unlikely.
- added `mprocs.log` to gitignore since mprocs sometimes generates it.
