### PR TITLE
Use DrvId for derivation model and enforce the structure of its content

### DIFF
--- a/backend/server/src/db/insert.rs
+++ b/backend/server/src/db/insert.rs
@@ -63,7 +63,8 @@ mod tests {
     use std::num::NonZeroU32;
 
     use crate::db::model::{
-        build::{DrvBuildCommand, DrvBuildId, DrvBuildResult, DrvBuildState, DrvId},
+        build::{DrvBuildCommand, DrvBuildId, DrvBuildResult, DrvBuildState},
+        drv::DrvId,
         git::{GitCommit, GitRepo},
     };
 

--- a/backend/server/src/db/model/build.rs
+++ b/backend/server/src/db/model/build.rs
@@ -15,7 +15,7 @@ use sqlx::{encode::IsNull, sqlite::SqliteArgumentValue, Decode, Encode, FromRow,
 
 use crate::db::model::git::{GitCommit, GitRepo};
 
-use super::ForInsert;
+use super::{drv::DrvId, ForInsert};
 
 /// Unique identifier for a derivation build attempt.
 ///
@@ -278,40 +278,6 @@ pub enum DrvBuildInterruptionKind {
     /// derivation builds which do not have the status [`DrvBuildState::Completed`] whilst
     /// starting.
     SchedulerDeath,
-}
-
-/// A derivation identifier of the form `hash-name.drv`.
-///
-/// Many derivations that describe a package (binaries, libraries, ...) additionally include a
-/// version identifier in the name component. For these derivations, the identifier often looks
-/// like `hash-name-version.drv`. This is however only a convention. Many intermediate build
-/// artifacts for example do not have a version.
-///
-/// Each derivation identifier corresponds to a file with the same name located in a nix store. The
-/// filesystem path of the store depends on the evaluator that produced the derivation and is part
-/// of the identifier's hash component[^nix-by-hand]. It is not possible to determine the store
-/// path given only a derivation identifier.
-///
-/// # Examples
-///
-/// Derivation for the hello package, version 2.12.1:
-/// `jd83l3jn2mkn530lgcg0y523jq5qji85-hello-2.12.1.drv`
-///
-/// Derivation for the source of an unknown other derivation:
-/// `0aykaqxhbby7mx7lgb217m9b3gkl52fn-source.drv`
-///
-/// [^nix-by-hand]: <https://bernsteinbear.com/blog/nix-by-hand/>
-#[derive(Clone, Debug, PartialEq, Eq, Type)]
-#[sqlx(transparent)]
-pub struct DrvId(String);
-
-/// Constructors and methods useful for testing.
-#[cfg(test)]
-impl DrvId {
-    /// Returns a known good derivation identifier. Useful for database inserts in tests.
-    pub fn dummy() -> Self {
-        DrvId("jd83l3jn2mkn530lgcg0y523jq5qji85-hello-2.12.1.drv".to_owned())
-    }
 }
 
 mod state {

--- a/backend/server/src/db/model/drv.rs
+++ b/backend/server/src/db/model/drv.rs
@@ -1,5 +1,12 @@
-use sqlx::{FromRow, Pool, Sqlite, Type};
-use std::{collections::HashMap, fmt};
+use sqlx::encode::IsNull;
+use sqlx::sqlite::SqliteArgumentValue;
+use sqlx::{Decode, Encode, FromRow, Pool, Sqlite, Type};
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::fmt;
+use std::ops::Deref;
+use std::path::Path;
 use tracing::debug;
 
 /// A derivation identifier of the form `hash-name.drv`.
@@ -17,22 +24,170 @@ use tracing::debug;
 /// # Examples
 ///
 /// Derivation for the hello package, version 2.12.1:
-/// `jd83l3jn2mkn530lgcg0y523jq5qji85-hello-2.12.1.drv`
+/// ```
+/// DrvId::try_from("jd83l3jn2mkn530lgcg0y523jq5qji85-hello-2.12.1.drv")
+/// ```
 ///
 /// Derivation for the source of an unknown other derivation:
-/// `0aykaqxhbby7mx7lgb217m9b3gkl52fn-source.drv`
+/// ```
+/// DrvId::try_from("0aykaqxhbby7mx7lgb217m9b3gkl52fn-source.drv")
+/// ```
+///
+/// The `try_from` implementation strips any store paths from the input and enforces that the given
+/// derivation identifier matches the `hash-name.drv` pattern. It also works with `&Path` inputs.
 ///
 /// [^nix-by-hand]: <https://bernsteinbear.com/blog/nix-by-hand/>
-#[derive(Clone, Debug, Hash, PartialEq, Eq, Type)]
-#[sqlx(transparent)]
-pub struct DrvId(pub String);
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct DrvId(String);
 
-/// Constructors and methods useful for testing.
-#[cfg(test)]
+// This type is really just a string, that we enforce to be of a certain structure, as such, it
+// makes sense that all read-only methods on str should be available on this type as well.
+impl Deref for DrvId {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+// The double reference is a bit weird, but this is the correct way of implementing `PartialEq` for
+// comparison with strings, because it is the only impl that allows `drvid == "asdf"` to compile.
+impl PartialEq<&str> for DrvId {
+    fn eq(&self, other: &&str) -> bool {
+        str::eq(self, *other)
+    }
+}
+
+/// Helper implementations.
 impl DrvId {
-    /// Returns a known good derivation identifier. Useful for database inserts in tests.
-    pub fn dummy() -> Self {
-        DrvId("jd83l3jn2mkn530lgcg0y523jq5qji85-hello-2.12.1.drv".to_owned())
+    /// Strips any store path from the input, if one exists.
+    fn strip_store_path(path: &str) -> &str {
+        match path.rsplit_once('/') {
+            Some((_, file_name)) => file_name,
+            None => path,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Invalid derivation identifier")]
+pub struct InvalidDrvId;
+
+impl TryFrom<&Path> for DrvId {
+    type Error = InvalidDrvId;
+
+    fn try_from(value: &Path) -> Result<Self, Self::Error> {
+        let file_name = value
+            .file_name()
+            .and_then(OsStr::to_str)
+            .ok_or(InvalidDrvId)?;
+
+        file_name.try_into()
+    }
+}
+
+impl TryFrom<&str> for DrvId {
+    type Error = InvalidDrvId;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        // enforce that derivation identifiers have a `drv` extension
+        match value.rsplit_once('.') {
+            Some((_, "drv")) => {} // all is well
+            _ => return Err(InvalidDrvId),
+        };
+
+        // strip any potential store paths
+        let id = DrvId::strip_store_path(value);
+
+        // enforce that derivation identifiers match the `hash-name` pattern
+        match id.split_once('-') {
+            Some((hash, _)) if hash.len() == 32 => {} // all is well
+            _ => return Err(InvalidDrvId),
+        }
+
+        Ok(Self(id.to_owned()))
+    }
+}
+
+impl<'q> Encode<'q, Sqlite> for DrvId {
+    fn encode_by_ref(
+        &self,
+        buf: &mut <Sqlite as sqlx::Database>::ArgumentBuffer<'q>,
+    ) -> Result<IsNull, sqlx::error::BoxDynError> {
+        // Using `Cow::Borrowed` is not possible because &self does not necessarily outlive 'q.
+        buf.push(SqliteArgumentValue::Text(Cow::Owned(self.0.clone())));
+        Ok(IsNull::No)
+    }
+
+    // Avoid the clone is `encode_by_ref` by overwriting the default impl of this method.
+    fn encode(
+        self,
+        buf: &mut <Sqlite as sqlx::Database>::ArgumentBuffer<'q>,
+    ) -> Result<IsNull, sqlx::error::BoxDynError>
+    where
+        Self: Sized,
+    {
+        buf.push(SqliteArgumentValue::Text(Cow::Owned(self.0)));
+        Ok(IsNull::No)
+    }
+
+    fn size_hint(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<'r> Decode<'r, Sqlite> for DrvId {
+    fn decode(
+        value: <Sqlite as sqlx::Database>::ValueRef<'r>,
+    ) -> Result<Self, sqlx::error::BoxDynError> {
+        Ok(<&str as Decode<'r, Sqlite>>::decode(value)?.try_into()?)
+    }
+}
+
+impl Type<Sqlite> for DrvId {
+    fn type_info() -> <Sqlite as sqlx::Database>::TypeInfo {
+        <&str as Type<Sqlite>>::type_info()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::DrvId;
+
+    /// Constructors and methods useful for testing.
+    impl DrvId {
+        /// Returns a known good derivation identifier. Useful for database inserts in tests.
+        pub fn dummy() -> Self {
+            DrvId("jd83l3jn2mkn530lgcg0y523jq5qji85-hello-2.12.1.drv".to_owned())
+        }
+    }
+
+    #[test]
+    fn drv_id_try_from() {
+        let _ = DrvId::try_from("jd83l3jn2mkn530lgcg0y523jq5qji85-hello-2.12.1.drv").unwrap();
+        let _ = DrvId::try_from("0aykaqxhbby7mx7lgb217m9b3gkl52fn-source.drv").unwrap();
+
+        assert_eq!(
+            DrvId::try_from(Path::new(
+                "/nix/store/0aykaqxhbby7mx7lgb217m9b3gkl52fn-source.drv",
+            ))
+            .unwrap(),
+            "0aykaqxhbby7mx7lgb217m9b3gkl52fn-source.drv"
+        );
+        assert_eq!(
+            DrvId::try_from(Path::new(
+                "/some/other/path/jd83l3jn2mkn530lgcg0y523jq5qji85-hello-2.12.1.drv"
+            ))
+            .unwrap(),
+            "jd83l3jn2mkn530lgcg0y523jq5qji85-hello-2.12.1.drv"
+        );
+
+        let _ = DrvId::try_from("").unwrap_err();
+        let _ = DrvId::try_from("jd83l3jn2mkn530lgcg0y523jq5qji85-hello-2.12.1").unwrap_err();
+        let _ = DrvId::try_from("jd83l3jn2mkn530lgcg0y523jq5qji85.drv").unwrap_err();
+        let _ = DrvId::try_from("hello-2.12.1.drv").unwrap_err();
     }
 }
 
@@ -63,16 +218,9 @@ impl fmt::Debug for Drv {
     }
 }
 
-pub fn strip_store_prefix(drv_path: &str) -> String {
-    drv_path
-        .strip_prefix("/nix/store/")
-        .unwrap_or(&drv_path)
-        .to_string()
-}
-
 pub async fn has_drv(pool: &Pool<Sqlite>, drv_path: &str) -> anyhow::Result<bool> {
     let result = sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM Drv WHERE drv_path = $1)")
-        .bind(strip_store_prefix(drv_path))
+        .bind(DrvId::strip_store_path(drv_path))
         .fetch_one(pool)
         .await?;
     Ok(result)

--- a/backend/server/src/db/model/drv.rs
+++ b/backend/server/src/db/model/drv.rs
@@ -4,7 +4,6 @@ use sqlx::{Decode, Encode, FromRow, Pool, Sqlite, Type};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ffi::OsStr;
-use std::fmt;
 use std::ops::Deref;
 use std::path::Path;
 use tracing::debug;
@@ -191,31 +190,13 @@ mod tests {
     }
 }
 
-#[derive(Clone, FromRow)]
+#[derive(Clone, Debug, FromRow)]
 pub struct Drv {
     /// Derivation identifier.
     pub derivation: DrvId,
 
     /// to reattempt the build (depending on the interruption kind).
     pub system: String,
-}
-
-impl Drv {
-    pub fn full_drv_path(&self) -> String {
-        format!("/nix/store/{}", &self.derivation.0)
-    }
-}
-
-impl fmt::Debug for Drv {
-    // Allow for debug output to resemble expected output
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{{ drv_path:{}, system:{} }}",
-            self.full_drv_path(),
-            &self.system
-        )
-    }
 }
 
 pub async fn has_drv(pool: &Pool<Sqlite>, drv_path: &str) -> anyhow::Result<bool> {

--- a/backend/server/src/db/service.rs
+++ b/backend/server/src/db/service.rs
@@ -6,6 +6,7 @@ use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePool};
 use tracing::{debug, info};
 
 use super::insert;
+use super::model::drv::DrvId;
 use super::model::{build::DrvBuildMetadata, drv, ForInsert};
 
 #[derive(Clone)]
@@ -56,7 +57,7 @@ impl DbService {
 
     pub async fn insert_drv_graph(
         &self,
-        drv_graph: HashMap<String, Vec<String>>,
+        drv_graph: HashMap<DrvId, Vec<DrvId>>,
     ) -> anyhow::Result<()> {
         drv::insert_drv_graph(&self.pool, drv_graph).await
     }

--- a/backend/server/src/nix/mod.rs
+++ b/backend/server/src/nix/mod.rs
@@ -1,10 +1,7 @@
 pub mod jobs;
 pub mod nix_eval_jobs;
 
-use crate::db::{
-    model::drv::{strip_store_prefix, DrvId},
-    DbService,
-};
+use crate::db::{model::drv::DrvId, DbService};
 use anyhow::Result;
 use std::{collections::HashMap, process::Command};
 use tokio::sync::mpsc::Receiver;
@@ -97,11 +94,11 @@ impl EvalService {
         self.drv_map
             .insert(drv_path.to_string(), references.clone());
         new_drvs.insert(
-            DrvId(strip_store_prefix(drv_path)),
+            drv_path.try_into()?,
             references
                 .iter()
-                .map(|s| DrvId(strip_store_prefix(s)))
-                .collect(),
+                .map(|s| DrvId::try_from(s.as_str()))
+                .collect::<Result<_, _>>()?,
         );
 
         for drv in references.into_iter() {


### PR DESCRIPTION
As the title says :)

See individual commits for more information.