### PR TITLE
backend/server: Graceful Shutdowns #44

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -520,6 +520,7 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -2576,9 +2577,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",

--- a/backend/server/Cargo.toml
+++ b/backend/server/Cargo.toml
@@ -26,6 +26,7 @@ shared = { workspace = true }
 sqlx = { version = "0.8.5", features = [ "runtime-tokio", "sqlite", "migrate", "macros", "chrono" ], default-features = false }
 thiserror = { workspace = true }
 tokio = { version = "1.41.0", features = ["full"] }
+tokio-util = "0.7.15"
 tower-http = { version = "0.6.2", features = ["fs", "tracing"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/backend/server/src/db/service.rs
+++ b/backend/server/src/db/service.rs
@@ -61,8 +61,4 @@ impl DbService {
     ) -> anyhow::Result<()> {
         drv::insert_drv_graph(&self.pool, drv_graph).await
     }
-
-    pub async fn close(self) {
-        self.pool.close().await
-    }
 }

--- a/backend/server/src/db/service.rs
+++ b/backend/server/src/db/service.rs
@@ -61,4 +61,8 @@ impl DbService {
     ) -> anyhow::Result<()> {
         drv::insert_drv_graph(&self.pool, drv_graph).await
     }
+
+    pub async fn close(self) {
+        self.pool.close().await
+    }
 }

--- a/backend/server/src/nix/mod.rs
+++ b/backend/server/src/nix/mod.rs
@@ -60,8 +60,6 @@ impl EvalService {
             }
         }
 
-        self.db_service.close().await;
-        info!("Database service pool closed");
         info!("Eval service shutdown gracefully");
     }
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730045389,
-        "narHash": "sha256-4spSNTZ6h8Xmvrr9oqfuxc9jarasGj1QOcsgw8BfNd8=",
+        "lastModified": 1748186667,
+        "narHash": "sha256-UQubDNIQ/Z42R8tPCIpY+BOhlxO8t8ZojwC9o2FW3c8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0fcb98acb6633445764dafe180e6833eb0f95208",
+        "rev": "bdac72d387dca7f836f6ef1fe547755fb0e9df61",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {

--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -1,4 +1,6 @@
 {
+  lib,
+  stdenv,
   cargo,
   clippy,
   elmPackages,
@@ -13,18 +15,22 @@
 }:
 
 mkShell {
-  nativeBuildInputs = [
-    cargo
-    clippy
-    pkg-config
-    nix-eval-jobs
-    rustc
-    rustfmt
-    rust-analyzer
-    elmPackages.elm
-    elmPackages.elm-format
-    dev-server
-  ];
+  nativeBuildInputs =
+    [
+      cargo
+      clippy
+      pkg-config
+      nix-eval-jobs
+      rustc
+      rustfmt
+      rust-analyzer
+      elmPackages.elm
+      dev-server
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      # Broken in nixpkgs for darwin?
+      elmPackages.elm-format
+    ];
 
   buildInputs = [
     openssl


### PR DESCRIPTION
Closes #44

The PR implements graceful shutdowns for the services handling SIGTERM and SIGINT using CancellationToken from the tokio-util crate. Which is a transitive-dependency of ours (from tower-http's fs feature), so we aren't adding any new dependency to the tree.

~~The PR Is still WIP due to my rust skill issue trying to figure out how to close the db_service in the simplest way given it is being passed to the eval_service.~~