### PR TITLE
Query graph

### DIFF
--- a/backend/server/src/db/model/drv/mod.rs
+++ b/backend/server/src/db/model/drv/mod.rs
@@ -2,6 +2,7 @@ use crate::db::model::build_event::DrvBuildState;
 use crate::db::model::DrvId;
 use sqlx::FromRow;
 use std::str::FromStr;
+use std::hash::{Hash, Hasher};
 
 mod queries;
 pub use queries::*;
@@ -32,5 +33,20 @@ impl Drv {
             required_system_features: drv_output.required_system_features,
             build_state: DrvBuildState::Queued,
         })
+    }
+}
+
+impl PartialEq for Drv {
+    fn eq(&self, other: &Self) -> bool {
+        self.drv_path == other.drv_path
+    }
+}
+
+impl Eq for Drv {}
+
+impl Hash for Drv {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Only hash drvId as it should always be unique
+        self.drv_path.hash(state);
     }
 }

--- a/backend/server/src/db/model/drv/mod.rs
+++ b/backend/server/src/db/model/drv/mod.rs
@@ -1,8 +1,8 @@
 use crate::db::model::build_event::DrvBuildState;
 use crate::db::model::DrvId;
 use sqlx::FromRow;
-use std::str::FromStr;
 use std::hash::{Hash, Hasher};
+use std::str::FromStr;
 
 mod queries;
 pub use queries::*;

--- a/backend/server/src/db/model/drv/queries.rs
+++ b/backend/server/src/db/model/drv/queries.rs
@@ -104,7 +104,7 @@ pub async fn insert_drvs_and_references(
                 .push_bind(&drv.build_state);
         });
 
-        query_builder.build().execute(&mut *tx).await?;
+        query_builder.build().persistent(false).execute(&mut *tx).await?;
         info!("Inserted {} new drvs", drvs.len());
     }
 

--- a/backend/server/src/db/model/drv/queries.rs
+++ b/backend/server/src/db/model/drv/queries.rs
@@ -80,9 +80,9 @@ pub async fn insert_drv_graph(
     Ok(())
 }
 
-/// This will insert a vec of <drv, referrence> into
-/// the database. This only creates the reference+referrer relationship
-/// Drvs are assumed to already be populated
+/// This will insert a slice of drvs and <reference, referrer> into
+/// the database. The reference relationships assume that the drvs
+/// have been inserted previously, or passed in this call as well
 pub async fn insert_drvs_and_references(
     pool: &Pool<Sqlite>,
     drvs: &[Drv],

--- a/backend/server/src/db/model/drv/queries.rs
+++ b/backend/server/src/db/model/drv/queries.rs
@@ -4,7 +4,7 @@ use crate::db::model::{drv_id, DrvId};
 use sqlx::SqlitePool;
 use sqlx::{Pool, Sqlite};
 use std::collections::HashMap;
-use tracing::debug;
+use tracing::{debug, info};
 
 pub async fn get_drv(derivation: &DrvId, pool: &Pool<Sqlite>) -> anyhow::Result<Option<Drv>> {
     let event = sqlx::query_as(
@@ -80,6 +80,50 @@ pub async fn insert_drv_graph(
     Ok(())
 }
 
+/// This will insert a vec of <drv, referrence> into
+/// the database. This only creates the reference+referrer relationship
+/// Drvs are assumed to already be populated
+pub async fn insert_drvs_and_references(
+    pool: &Pool<Sqlite>,
+    drvs: &Vec<Drv>,
+    drv_refs: &Vec<(DrvId, DrvId)>,
+) -> anyhow::Result<()> {
+    use sqlx::{QueryBuilder, Sqlite};
+
+    let mut tx = pool.begin().await?;
+
+    if !drvs.is_empty() {
+
+      let mut query_builder = QueryBuilder::new(
+          "INSERT INTO Drv (drv_path, system, required_system_features, build_state) ",
+      );
+
+      query_builder.push_values(drvs, |mut row, drv| {
+          row.push_bind(&drv.drv_path)
+              .push_bind(&drv.system)
+              .push_bind(&drv.required_system_features)
+              .push_bind(&drv.build_state);
+      });
+
+      query_builder.build().execute(&mut *tx).await?;
+      info!("Inserted {} new drvs", drvs.len());
+    }
+
+    if !drv_refs.is_empty() {
+      let mut reference_builder: QueryBuilder<Sqlite> =
+          QueryBuilder::new("INSERT INTO DrvRefs (referrer, reference) ");
+      reference_builder.push_values(drv_refs.iter(), |mut sep, (referrer, reference)| {
+          sep.push_bind(referrer).push_bind(reference);
+      });
+
+      reference_builder.build().execute(&mut *tx).await?;
+    }
+
+    tx.commit().await?;
+
+    Ok(())
+}
+
 /// To avoid two round trips, or multiple subqueries, we assume that the referrer
 /// was recently inserted, thus we know its id. The references will be added
 /// by their drv_path since that was not yet known
@@ -141,25 +185,6 @@ WHERE drv_path = ?2
     .await?;
 
     // TODO: emit build_event in the same transaction
-    Ok(())
-}
-
-async fn insert_drvs(categories: Vec<Drv>, pool: &Pool<Sqlite>) -> anyhow::Result<()> {
-    use sqlx::QueryBuilder;
-
-    let mut query_builder = QueryBuilder::new(
-        "INSERT INTO Drv (drv_path, system, required_system_features, build_state) ",
-    );
-
-    query_builder.push_values(categories, |mut row, drv| {
-        row.push_bind(drv.drv_path)
-            .push_bind(drv.system)
-            .push_bind(drv.required_system_features)
-            .push_bind(drv.build_state);
-    });
-
-    query_builder.build().execute(pool).await?;
-
     Ok(())
 }
 
@@ -272,7 +297,7 @@ mod tests {
 
         let drvs = vec![drv1, drv2, drv3];
 
-        insert_drvs(drvs, &pool).await?;
+        insert_drvs_and_references(&pool, &drvs, &Vec::new()).await?;
 
         let result = get_derivations_in_state(DrvBuildState::Queued, &pool).await?;
 

--- a/backend/server/src/db/model/drv/queries.rs
+++ b/backend/server/src/db/model/drv/queries.rs
@@ -85,8 +85,8 @@ pub async fn insert_drv_graph(
 /// Drvs are assumed to already be populated
 pub async fn insert_drvs_and_references(
     pool: &Pool<Sqlite>,
-    drvs: &Vec<Drv>,
-    drv_refs: &Vec<(DrvId, DrvId)>,
+    drvs: &[Drv],
+    drv_refs: &[(DrvId, DrvId)],
 ) -> anyhow::Result<()> {
     use sqlx::{QueryBuilder, Sqlite};
 

--- a/backend/server/src/db/service.rs
+++ b/backend/server/src/db/service.rs
@@ -68,8 +68,8 @@ impl DbService {
 
     pub async fn insert_drvs_and_references(
         &self,
-        drvs: &Vec<Drv>,
-        drv_refs: &Vec<(DrvId, DrvId)>,
+        drvs: &[Drv],
+        drv_refs: &[(DrvId, DrvId)],
     ) -> anyhow::Result<()> {
         drv::insert_drvs_and_references(&self.pool, drvs, drv_refs).await
     }

--- a/backend/server/src/db/service.rs
+++ b/backend/server/src/db/service.rs
@@ -6,8 +6,8 @@ use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePool};
 use tracing::{debug, info};
 
 use super::insert;
-use super::model::{drv_id::DrvId, drv::Drv};
 use super::model::{build::DrvBuildMetadata, build_event, drv, ForInsert};
+use super::model::{drv::Drv, drv_id::DrvId};
 
 #[derive(Clone)]
 pub struct DbService {

--- a/backend/server/src/db/service.rs
+++ b/backend/server/src/db/service.rs
@@ -6,7 +6,7 @@ use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePool};
 use tracing::{debug, info};
 
 use super::insert;
-use super::model::drv_id::DrvId;
+use super::model::{drv_id::DrvId, drv::Drv};
 use super::model::{build::DrvBuildMetadata, build_event, drv, ForInsert};
 
 #[derive(Clone)]
@@ -64,6 +64,14 @@ impl DbService {
 
     pub async fn drv_referrers(&self, drv: &DrvId) -> anyhow::Result<Vec<DrvId>> {
         drv::drv_referrers(&self.pool, &drv).await
+    }
+
+    pub async fn insert_drvs_and_references(
+        &self,
+        drvs: &Vec<Drv>,
+        drv_refs: &Vec<(DrvId, DrvId)>,
+    ) -> anyhow::Result<()> {
+        drv::insert_drvs_and_references(&self.pool, drvs, drv_refs).await
     }
 
     pub async fn insert_drv_graph(

--- a/backend/server/src/nix/derivation_show.rs
+++ b/backend/server/src/nix/derivation_show.rs
@@ -28,12 +28,20 @@ pub struct DrvInfo {
 
 /// Do `nix derivation show` but filter for the things we care about
 pub async fn drv_output(drv_path: &str) -> anyhow::Result<DrvInfo> {
+    use anyhow::bail;
+
     debug!("Fetching derivation information, {:?}", &drv_path);
     let output = Command::new("nix")
         .args(["derivation", "show", drv_path])
         .output()
         .await?
         .stdout;
+    if output.is_empty() {
+        bail!("failed to fetch info for {:?}", drv_path);
+    } else {
+        debug!("Successfully fetched info for {}", drv_path);
+    }
+
     let str = String::from_utf8(output)?;
     let drv_output: DrvOutput = serde_json::from_str(&str)?;
     let drv_info = drv_output


### PR DESCRIPTION
Instead of "walking" the drv DAG, just query for requisites (to populate drvs) and query the `--graph` which then gives all of the drv graph.

This effectively makes the big O from O(N) to O(1). In the future, it might be slightly better to do the old traversal if the drv delta is reasonably small.

closes #91