### PR TITLE
chore: comment out unused code

### DIFF
--- a/backend/server/src/db/insert.rs
+++ b/backend/server/src/db/insert.rs
@@ -1,37 +1,40 @@
 use sqlx::SqlitePool;
 
-use super::model::{build::DrvBuildMetadata, build_event::DrvBuildEvent, ForInsert};
+use super::model::{build_event::DrvBuildEvent, ForInsert};
 
-pub async fn new_drv_build_metadata(
-    metadata: ForInsert<DrvBuildMetadata>,
-    pool: &SqlitePool,
-) -> anyhow::Result<DrvBuildMetadata> {
-    let metadata = metadata.0;
-    let metadata = sqlx::query_as(
-        r#"
-INSERT INTO DrvBuildMetadata
-    (derivation, git_repo, git_commit, build_command, build_attempt)
-VALUES (
-    ?1, ?2, ?3, ?4,
-    IFNULL(
-        (SELECT MAX(build_attempt) + 1
-            FROM DrvBuildMetadata
-            WHERE derivation = ?1),
-        1
-    )
-)
-RETURNING derivation, build_attempt, git_repo, git_commit, build_command
-        "#,
-    )
-    .bind(&metadata.build.derivation)
-    .bind(&metadata.git_repo)
-    .bind(&metadata.git_commit)
-    .bind(&metadata.build_command)
-    .fetch_one(pool)
-    .await?;
-
-    Ok(metadata)
-}
+// Althought this isn't currently being used, eventually we
+// should emit when a build progresses
+//
+// pub async fn new_drv_build_metadata(
+//     metadata: ForInsert<DrvBuildMetadata>,
+//     pool: &SqlitePool,
+// ) -> anyhow::Result<DrvBuildMetadata> {
+//     let metadata = metadata.0;
+//     let metadata = sqlx::query_as(
+//         r#"
+// INSERT INTO DrvBuildMetadata
+//     (derivation, git_repo, git_commit, build_command, build_attempt)
+// VALUES (
+//     ?1, ?2, ?3, ?4,
+//     IFNULL(
+//         (SELECT MAX(build_attempt) + 1
+//             FROM DrvBuildMetadata
+//             WHERE derivation = ?1),
+//         1
+//     )
+// )
+// RETURNING derivation, build_attempt, git_repo, git_commit, build_command
+//         "#,
+//     )
+//     .bind(&metadata.build.derivation)
+//     .bind(&metadata.git_repo)
+//     .bind(&metadata.git_commit)
+//     .bind(&metadata.build_command)
+//     .fetch_one(pool)
+//     .await?;
+//
+//     Ok(metadata)
+// }
 
 pub async fn new_drv_build_event(
     event: ForInsert<DrvBuildEvent>,
@@ -60,80 +63,79 @@ mod tests {
     use std::num::NonZeroU32;
 
     use crate::db::model::{
-        build::{DrvBuildCommand, DrvBuildId},
+        build::DrvBuildId,
         build_event::{DrvBuildResult, DrvBuildState},
         drv_id::DrvId,
-        git::{GitCommit, GitRepo},
     };
 
     use super::*;
 
-    #[sqlx::test(migrations = "./sql/migrations")]
-    async fn insert_metadata_new_drv(pool: SqlitePool) -> anyhow::Result<()> {
-        let metadata = DrvBuildMetadata::for_insert(
-            DrvId::dummy(),
-            GitRepo(gix_url::parse(
-                "https://github.com/ekala-project/eka-ci".into(),
-            )?),
-            GitCommit(gix_hash::ObjectId::from_hex(
-                b"ad7fb3f7660de7435baf14af66edef106dcffff9",
-            )?),
-            DrvBuildCommand::dummy(),
-        );
+    // #[sqlx::test(migrations = "./sql/migrations")]
+    // async fn insert_metadata_new_drv(pool: SqlitePool) -> anyhow::Result<()> {
+    //     let metadata = DrvBuildMetadata::for_insert(
+    //         DrvId::dummy(),
+    //         GitRepo(gix_url::parse(
+    //             "https://github.com/ekala-project/eka-ci".into(),
+    //         )?),
+    //         GitCommit(gix_hash::ObjectId::from_hex(
+    //             b"ad7fb3f7660de7435baf14af66edef106dcffff9",
+    //         )?),
+    //         DrvBuildCommand::dummy(),
+    //     );
 
-        let inserted = new_drv_build_metadata(metadata.clone(), &pool).await?;
+    //     let inserted = new_drv_build_metadata(metadata.clone(), &pool).await?;
 
-        // some sanity checks that the correct metadata record is returned
-        assert_eq!(&inserted.build.derivation, &metadata.0.build.derivation);
-        assert_eq!(&inserted.git_repo, &metadata.0.git_repo);
-        assert_eq!(&inserted.git_commit, &metadata.0.git_commit);
-        assert_eq!(&inserted.build_command, &metadata.0.build_command);
+    //     // some sanity checks that the correct metadata record is returned
+    //     assert_eq!(&inserted.build.derivation, &metadata.0.build.derivation);
+    //     assert_eq!(&inserted.git_repo, &metadata.0.git_repo);
+    //     assert_eq!(&inserted.git_commit, &metadata.0.git_commit);
+    //     assert_eq!(&inserted.build_command, &metadata.0.build_command);
 
-        // check that the build attempt was assigned correctly
-        assert_eq!(inserted.build.build_attempt.get(), 1u32);
+    //     // check that the build attempt was assigned correctly
+    //     assert_eq!(inserted.build.build_attempt.get(), 1u32);
 
-        Ok(())
-    }
+    //     Ok(())
+    // }
 
-    #[sqlx::test(migrations = "./sql/migrations")]
-    async fn insert_metadata_existing_drv(pool: SqlitePool) -> anyhow::Result<()> {
-        sqlx::query(
-            r#"
-INSERT INTO DrvBuildMetadata (derivation, build_attempt, git_repo, git_commit, build_command)
-VALUES (?, 1, 'https://github.com/ekala-project/corepkgs', '0000000000000000000000000000000000000000', ?)
-            "#,
-        )
-        .bind(DrvId::dummy())
-        .bind(DrvBuildCommand::dummy())
-        .execute(&pool)
-        .await?;
+    // #[sqlx::test(migrations = "./sql/migrations")]
+    // async fn insert_metadata_existing_drv(pool: SqlitePool) -> anyhow::Result<()> {
+    //     sqlx::query(
+    //         r#"
+// INSERT INTO DrvBuildMetadata (derivation, build_attempt, git_repo, git_commit, build_command)
+// VALUES (?, 1, 'https://github.com/ekala-project/corepkgs', '0000000000000000000000000000000000000000', ?)
+    //         "#,
+    //     )
+    //     .bind(DrvId::dummy())
+    //     .bind(DrvBuildCommand::dummy())
+    //     .execute(&pool)
+    //     .await?;
 
-        let metadata = DrvBuildMetadata::for_insert(
-            DrvId::dummy(),
-            GitRepo(gix_url::parse(
-                "https://github.com/ekala-project/corepkgs".into(),
-            )?),
-            GitCommit(gix_hash::ObjectId::from_hex(
-                b"1111111111111111111111111111111111111111",
-            )?),
-            DrvBuildCommand::dummy(),
-        );
+    //     let metadata = DrvBuildMetadata::for_insert(
+    //         DrvId::dummy(),
+    //         GitRepo(gix_url::parse(
+    //             "https://github.com/ekala-project/corepkgs".into(),
+    //         )?),
+    //         GitCommit(gix_hash::ObjectId::from_hex(
+    //             b"1111111111111111111111111111111111111111",
+    //         )?),
+    //         DrvBuildCommand::dummy(),
+    //     );
 
-        // should create a new entry with build attempt counter set to 2 because another entry
-        // for the same derivation already exists
-        let inserted = new_drv_build_metadata(metadata.clone(), &pool).await?;
+    //     // should create a new entry with build attempt counter set to 2 because another entry
+    //     // for the same derivation already exists
+    //     let inserted = new_drv_build_metadata(metadata.clone(), &pool).await?;
 
-        // some sanity checks that the correct metadata record is returned
-        assert_eq!(&inserted.build.derivation, &metadata.0.build.derivation);
-        assert_eq!(&inserted.git_repo, &metadata.0.git_repo);
-        assert_eq!(&inserted.git_commit, &metadata.0.git_commit);
-        assert_eq!(&inserted.build_command, &metadata.0.build_command);
+    //     // some sanity checks that the correct metadata record is returned
+    //     assert_eq!(&inserted.build.derivation, &metadata.0.build.derivation);
+    //     assert_eq!(&inserted.git_repo, &metadata.0.git_repo);
+    //     assert_eq!(&inserted.git_commit, &metadata.0.git_commit);
+    //     assert_eq!(&inserted.build_command, &metadata.0.build_command);
 
-        // check that the build attempt was assigned correctly
-        assert_eq!(inserted.build.build_attempt.get(), 2u32);
+    //     // check that the build attempt was assigned correctly
+    //     assert_eq!(inserted.build.build_attempt.get(), 2u32);
 
-        Ok(())
-    }
+    //     Ok(())
+    // }
 
     #[sqlx::test(migrations = "./sql/migrations")]
     async fn insert_event(pool: SqlitePool) -> anyhow::Result<()> {

--- a/backend/server/src/db/insert.rs
+++ b/backend/server/src/db/insert.rs
@@ -101,8 +101,8 @@ mod tests {
     // async fn insert_metadata_existing_drv(pool: SqlitePool) -> anyhow::Result<()> {
     //     sqlx::query(
     //         r#"
-// INSERT INTO DrvBuildMetadata (derivation, build_attempt, git_repo, git_commit, build_command)
-// VALUES (?, 1, 'https://github.com/ekala-project/corepkgs', '0000000000000000000000000000000000000000', ?)
+    // INSERT INTO DrvBuildMetadata (derivation, build_attempt, git_repo, git_commit, build_command)
+    // VALUES (?, 1, 'https://github.com/ekala-project/corepkgs', '0000000000000000000000000000000000000000', ?)
     //         "#,
     //     )
     //     .bind(DrvId::dummy())

--- a/backend/server/src/db/service.rs
+++ b/backend/server/src/db/service.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::path::Path;
 
 use sqlx::migrate;
@@ -6,7 +5,7 @@ use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePool};
 use tracing::{debug, info};
 
 use super::insert;
-use super::model::{build::DrvBuildMetadata, build_event, drv, ForInsert};
+use super::model::{build_event, drv, ForInsert};
 use super::model::{drv::Drv, drv_id::DrvId};
 
 #[derive(Clone)]
@@ -43,24 +42,24 @@ impl DbService {
         Ok(DbService { pool })
     }
 
-    pub async fn insert_build(
-        &self,
-        metadata: ForInsert<DrvBuildMetadata>,
-    ) -> anyhow::Result<DrvBuildMetadata> {
-        insert::new_drv_build_metadata(metadata, &self.pool).await
-    }
+    //pub async fn insert_build(
+    //    &self,
+    //    metadata: ForInsert<DrvBuildMetadata>,
+    //) -> anyhow::Result<DrvBuildMetadata> {
+    //    insert::new_drv_build_metadata(metadata, &self.pool).await
+    //}
 
     pub async fn get_drv(&self, drv_path: &DrvId) -> anyhow::Result<Option<drv::Drv>> {
         drv::get_drv(drv_path, &self.pool).await
     }
 
-    pub async fn has_drv(&self, drv_path: &str) -> anyhow::Result<bool> {
-        drv::has_drv(&self.pool, drv_path).await
-    }
+    //pub async fn has_drv(&self, drv_path: &str) -> anyhow::Result<bool> {
+    //    drv::has_drv(&self.pool, drv_path).await
+    //}
 
-    pub async fn drv_references(&self, drv: &DrvId) -> anyhow::Result<Vec<drv::Drv>> {
-        drv::drv_references(&self.pool, &drv).await
-    }
+    //pub async fn drv_references(&self, drv: &DrvId) -> anyhow::Result<Vec<drv::Drv>> {
+    //    drv::drv_references(&self.pool, &drv).await
+    //}
 
     pub async fn drv_referrers(&self, drv: &DrvId) -> anyhow::Result<Vec<DrvId>> {
         drv::drv_referrers(&self.pool, &drv).await
@@ -74,12 +73,12 @@ impl DbService {
         drv::insert_drvs_and_references(&self.pool, drvs, drv_refs).await
     }
 
-    pub async fn insert_drv_graph(
-        &self,
-        drv_graph: &HashMap<DrvId, Vec<DrvId>>,
-    ) -> anyhow::Result<()> {
-        drv::insert_drv_graph(&self.pool, drv_graph).await
-    }
+    //pub async fn insert_drv_graph(
+    //    &self,
+    //    drv_graph: &HashMap<DrvId, Vec<DrvId>>,
+    //) -> anyhow::Result<()> {
+    //    drv::insert_drv_graph(&self.pool, drv_graph).await
+    //}
 
     pub async fn new_drv_build_event(
         &self,

--- a/backend/server/src/nix/mod.rs
+++ b/backend/server/src/nix/mod.rs
@@ -141,25 +141,25 @@ fn drv_requisites(drv_path: &str) -> Result<Vec<DrvId>> {
     Ok(drvs)
 }
 
-/// Retreive the direct dependencies of a drv
-fn drv_references(drv_path: &str) -> Result<Vec<String>> {
-    let output = Command::new("nix-store")
-        .args(["--query", "--references", drv_path])
-        .output()?
-        .stdout;
-    let drv_str = String::from_utf8(output)?;
-
-    let drvs = drv_str
-        .lines()
-        // drv references can include "inputSrcs" which are not inputDrvs
-        // but rather files which were added to the nix store through
-        // path literals or `nix-store --add`
-        .filter(|x| x.ends_with(".drv"))
-        .map(|x| x.to_string())
-        .collect::<Vec<String>>();
-
-    Ok(drvs)
-}
+// Retreive the direct dependencies of a drv
+//fn drv_references(drv_path: &str) -> Result<Vec<String>> {
+//    let output = Command::new("nix-store")
+//        .args(["--query", "--references", drv_path])
+//        .output()?
+//        .stdout;
+//    let drv_str = String::from_utf8(output)?;
+//
+//    let drvs = drv_str
+//        .lines()
+//        // drv references can include "inputSrcs" which are not inputDrvs
+//        // but rather files which were added to the nix store through
+//        // path literals or `nix-store --add`
+//        .filter(|x| x.ends_with(".drv"))
+//        .map(|x| x.to_string())
+//        .collect::<Vec<String>>();
+//
+//    Ok(drvs)
+//}
 
 fn graph_line_to_drvids(drv_line: &str) -> Result<(DrvId, DrvId)> {
     let mut line = drv_line.split(" ");

--- a/backend/server/src/scheduler/ingress.rs
+++ b/backend/server/src/scheduler/ingress.rs
@@ -1,7 +1,6 @@
-use crate::db::model::{build, drv_id, git};
+use crate::db::model::drv_id;
 use crate::db::DbService;
 use crate::scheduler::builder::BuildRequest;
-use std::collections::HashMap;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tracing::{debug, warn};
@@ -119,31 +118,31 @@ impl IngressWorker {
     }
 }
 
-/// Since we have to do a lot of construction, make this its own method
-async fn insert_metadata(
-    drv_id: drv_id::DrvId,
-    db_service: &DbService,
-) -> anyhow::Result<build::DrvBuildMetadata> {
-    // TODO: Originating source should be passed. For now, just fill
-    // with fake information
-    let repo = git::GitRepo(gix_url::parse(
-        "https://github.com/ekala-project/fake-ci".into(),
-    )?);
-    let commit = git::GitCommit(gix_hash::ObjectId::from_hex(
-        b"1f5cfe6827dc7956af7da54755717202d14667a0",
-    )?);
-    // Eventually, we will want to be able to re-create the .drv on
-    // a potentially remote store, for now, we just assume that the .drv
-    // exists in the local eval store and have this command be dummy data
-    let command = build::DrvBuildCommand::SingleAttr {
-        exec: "/bin/nix".into(),
-        args: Vec::new(),
-        env: HashMap::new(),
-        file: "/path/to/file.nix".into(),
-        attr: "hello".to_owned(),
-    };
-
-    debug!("Inserting DrvMetadata {:?}", &drv_id);
-    let metadata = build::DrvBuildMetadata::for_insert(drv_id, repo, commit, command);
-    db_service.insert_build(metadata).await
-}
+// Since we have to do a lot of construction, make this its own method
+// async fn insert_metadata(
+//     drv_id: drv_id::DrvId,
+//     db_service: &DbService,
+// ) -> anyhow::Result<build::DrvBuildMetadata> {
+//     // TODO: Originating source should be passed. For now, just fill
+//     // with fake information
+//     let repo = git::GitRepo(gix_url::parse(
+//         "https://github.com/ekala-project/fake-ci".into(),
+//     )?);
+//     let commit = git::GitCommit(gix_hash::ObjectId::from_hex(
+//         b"1f5cfe6827dc7956af7da54755717202d14667a0",
+//     )?);
+//     // Eventually, we will want to be able to re-create the .drv on
+//     // a potentially remote store, for now, we just assume that the .drv
+//     // exists in the local eval store and have this command be dummy data
+//     let command = build::DrvBuildCommand::SingleAttr {
+//         exec: "/bin/nix".into(),
+//         args: Vec::new(),
+//         env: HashMap::new(),
+//         file: "/path/to/file.nix".into(),
+//         attr: "hello".to_owned(),
+//     };
+//
+//     debug!("Inserting DrvMetadata {:?}", &drv_id);
+//     let metadata = build::DrvBuildMetadata::for_insert(drv_id, repo, commit, command);
+//     db_service.insert_build(metadata).await
+// }


### PR DESCRIPTION
got tired of seeing unused warnings. These usages were removed to simplify the usage of drv objects.