### PR TITLE
Git checkout

### DIFF
--- a/backend/client/src/cli/mod.rs
+++ b/backend/client/src/cli/mod.rs
@@ -16,6 +16,8 @@ pub(crate) enum Commands {
 
     Repo(t::RepoRequest),
 
+    Git(t::GitRequest),
+
     /// Inspect or Modify individual drvs
     #[command(subcommand)]
     Drv(DrvCommands),

--- a/backend/client/src/main.rs
+++ b/backend/client/src/main.rs
@@ -42,6 +42,10 @@ fn main() -> anyhow::Result<()> {
             send_request(&socket, ClientRequest::Info)
                 .context("failed to send info request to server")?;
         },
+        Some(Commands::Git(repo_info)) => {
+            send_request(&socket, ClientRequest::Git(repo_info))
+                .context("failed to send info request to server")?;
+        },
         Some(Commands::Status) => {},
         Some(Commands::Repo(repo_req)) => {
             let file_path = PathBuf::from(repo_req.file_path).canonicalize()?;

--- a/backend/server/src/git/actions.rs
+++ b/backend/server/src/git/actions.rs
@@ -1,0 +1,45 @@
+use std::path::Path;
+use std::process::Output;
+
+use anyhow::Result;
+use tokio::process::Command;
+use tracing::debug;
+
+pub async fn clone_git_repo(git_url: &str, path: &str) -> Result<Output> {
+    debug!("Attempting to checkout {} at {}", git_url, path);
+
+    let out = Command::new("git")
+        .args(["clone", git_url, path])
+        .output()
+        .await?;
+
+    Ok(out)
+}
+
+#[allow(dead_code)]
+pub async fn repo_is_healthy(path: &str) -> Result<bool> {
+    debug!("Checking if {} is a healthy git repository", &path);
+
+    let status = Command::new("git").args(["status", &path]).status().await?;
+
+    Ok(status.success())
+}
+
+pub async fn add_git_worktree<P: AsRef<Path>>(
+    repo_dir: P,
+    worktree_dir: &str,
+    commitish: &str,
+) -> Result<Output> {
+    debug!(
+        "Creating worktree at {} on commit {}",
+        worktree_dir, commitish
+    );
+
+    let out = Command::new("git")
+        .current_dir(repo_dir)
+        .args(["worktree", "add", "--detach", &worktree_dir, &commitish])
+        .output()
+        .await?;
+
+    Ok(out)
+}

--- a/backend/server/src/git/mod.rs
+++ b/backend/server/src/git/mod.rs
@@ -1,0 +1,79 @@
+mod actions;
+mod types;
+
+use anyhow::Result;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+pub use types::GitWorkspace;
+
+use crate::ci::RepoTask;
+
+#[derive(Debug, Clone)]
+pub enum GitTask {
+    Checkout(GitWorkspace),
+}
+
+pub struct GitService {
+    git_sender: mpsc::Sender<GitTask>,
+    git_receiver: mpsc::Receiver<GitTask>,
+}
+
+impl GitService {
+    pub fn new() -> Result<Self> {
+        let (git_sender, git_receiver) = mpsc::channel(1000);
+
+        Ok(Self {
+            git_sender,
+            git_receiver,
+        })
+    }
+
+    /// Producer channel for sending build requests for eventual scheduling
+    pub fn git_request_sender(&self) -> mpsc::Sender<GitTask> {
+        self.git_sender.clone()
+    }
+
+    pub fn run(
+        self,
+        repo_sender: mpsc::Sender<RepoTask>,
+        cancel_token: CancellationToken,
+    ) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            cancel_token
+                .run_until_cancelled(git_tasks_loop(self.git_receiver, repo_sender))
+                .await;
+        })
+    }
+}
+
+async fn git_tasks_loop(
+    mut receiver: mpsc::Receiver<GitTask>,
+    repo_sender: mpsc::Sender<RepoTask>,
+) {
+    loop {
+        if let Some(task) = receiver.recv().await {
+            debug!("Received git task {:?}", &task);
+            if let Err(e) = handle_git_task(task.clone(), &repo_sender).await {
+                warn!("Failed to handle ingress request {:?}: {:?}", &task, e);
+            }
+        }
+    }
+}
+
+async fn handle_git_task(
+    task: GitTask,
+    repo_sender: &mpsc::Sender<RepoTask>,
+) -> anyhow::Result<()> {
+    match task {
+        GitTask::Checkout(repo) => {
+            repo.ensure_master_clone().await?;
+            repo.create_worktree().await?;
+            let repo_task = RepoTask::Read(repo.worktree_path());
+            repo_sender.send(repo_task).await?;
+        },
+    }
+
+    Ok(())
+}

--- a/backend/server/src/git/types.rs
+++ b/backend/server/src/git/types.rs
@@ -1,0 +1,174 @@
+use std::path::PathBuf;
+
+use shared::types::GitRequest;
+use tracing::debug;
+
+use super::actions::{add_git_worktree, clone_git_repo};
+
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub enum GitProtocol {
+    Https,
+    Http,
+    Ssh,
+}
+
+impl GitProtocol {
+    /// Which protocol protocol prefix to use when constructing a git checkout url
+    pub fn protocol_prefix(&self) -> &str {
+        match self {
+            Self::Https => "https://",
+            Self::Http => "http://",
+            Self::Ssh => "git@",
+        }
+    }
+}
+
+/// Information to checkout a repository and a specific branch or commit
+#[derive(Clone, Debug)]
+pub struct GitRepo {
+    pub protocol: GitProtocol,
+    pub domain: String,
+    pub owner: String,
+    pub repo: String,
+}
+
+/// This is meant to provision a worktree
+/// To quicken checkout performance, we use a single "origin" to keep
+/// a running heap of git objects, then we can just use worktrees to create
+/// cheap per-commit directories
+#[derive(Clone, Debug)]
+pub struct GitWorkspace {
+    repo: GitRepo,
+    /// Branch, tag, or commit
+    rev_parse: String,
+    /// Non-worktree tree path
+    repo_path: PathBuf,
+    /// Worktree tree path
+    worktree_path: PathBuf,
+}
+
+impl GitRepo {
+    pub fn checkout_url(&self) -> String {
+        match self.protocol {
+            GitProtocol::Ssh => {
+                format!(
+                    "{}{}:{}/{}.git",
+                    self.protocol.protocol_prefix(),
+                    &self.domain,
+                    &self.owner,
+                    &self.repo
+                )
+            },
+            _ => {
+                format!(
+                    "{}{}/{}/{}.git",
+                    self.protocol.protocol_prefix(),
+                    &self.domain,
+                    &self.owner,
+                    &self.repo
+                )
+            },
+        }
+    }
+}
+
+impl GitWorkspace {
+    pub fn new(repo: GitRepo, rev_parse: String, mut repo_path_prefix: PathBuf) -> Self {
+        repo_path_prefix.push(&repo.domain);
+        repo_path_prefix.push(&repo.owner);
+        repo_path_prefix.push(&repo.repo);
+
+        let mut worktree_path = repo_path_prefix.clone();
+        worktree_path.push("worktrees");
+        worktree_path.push(&rev_parse);
+
+        repo_path_prefix.push("master");
+        Self {
+            repo,
+            rev_parse,
+            repo_path: repo_path_prefix,
+            worktree_path,
+        }
+    }
+
+    /// Ensure that the main clone exists and is healthy
+    pub async fn ensure_master_clone(&self) -> anyhow::Result<()> {
+        if !self.repo_path.exists() {
+            debug!("{:?} does not exist, creating", &self.repo_path);
+            std::fs::create_dir_all(&self.repo_path.parent().unwrap())?;
+            let dest_dir = self
+                .repo_path
+                .clone()
+                .into_os_string()
+                .into_string()
+                .unwrap();
+            clone_git_repo(&self.repo.checkout_url(), &dest_dir).await?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn create_worktree(&self) -> anyhow::Result<()> {
+        self.ensure_master_clone().await?;
+
+        if !self.worktree_path.exists() {
+            std::fs::create_dir_all(&self.worktree_path.parent().unwrap())?;
+            let dest_dir = self
+                .worktree_path
+                .clone()
+                .into_os_string()
+                .into_string()
+                .unwrap();
+            add_git_worktree(&self.repo_path, &dest_dir, &self.rev_parse).await?;
+        }
+
+        Ok(())
+    }
+
+    pub fn worktree_path(&self) -> PathBuf {
+        self.worktree_path.clone()
+    }
+
+    pub fn from_git_request(request: GitRequest, repo_path_prefix: PathBuf) -> Self {
+        let repo = GitRepo {
+            protocol: GitProtocol::Https,
+            domain: request.domain,
+            owner: request.owner,
+            repo: request.repo,
+        };
+
+        Self::new(repo, request.commitish, repo_path_prefix)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ssh_repo_url() {
+        let repo = GitRepo {
+            protocol: GitProtocol::Ssh,
+            domain: "github.com".to_string(),
+            owner: "XAMPPRocky".to_string(),
+            repo: "octocrab".to_string(),
+        };
+
+        let expected_url = "git@github.com:XAMPPRocky/octocrab.git";
+        assert_eq!(repo.checkout_url(), expected_url);
+    }
+
+    #[test]
+    fn test_https_repo_url() {
+        let repo = GitRepo {
+            protocol: GitProtocol::Https,
+            domain: "github.com".to_string(),
+            owner: "XAMPPRocky".to_string(),
+            repo: "octocrab".to_string(),
+        };
+
+        let expected_url = "https://github.com/XAMPPRocky/octocrab.git";
+        assert_eq!(repo.checkout_url(), expected_url);
+    }
+}

--- a/backend/shared/src/types/mod.rs
+++ b/backend/shared/src/types/mod.rs
@@ -9,6 +9,7 @@ pub enum ClientRequest {
     Build(BuildRequest),
     Job(JobRequest),
     Repo(RepoRequest),
+    Git(GitRequest),
     DrvStatus(DrvStatusRequest),
 }
 
@@ -31,6 +32,14 @@ pub enum ClientResponse {
     Info(InfoResponse),
     Ack(bool),
     DrvStatus(Option<DrvStatusResponse>),
+}
+
+#[derive(Serialize, Parser, Deserialize, Debug)]
+pub struct GitRequest {
+    pub domain: String,
+    pub owner: String,
+    pub repo: String,
+    pub commitish: String,
 }
 
 #[derive(Serialize, Parser, Deserialize, Debug)]


### PR DESCRIPTION
Adds initial support for doing git clone and git worktree.

The idea is that creating worktrees should be cheap as we don't have to fetch a bunch of git objects from first checkout each time.