### PR TITLE
Pass octocrab to webhandler

### DIFF
--- a/backend/server/src/services/mod.rs
+++ b/backend/server/src/services/mod.rs
@@ -28,14 +28,10 @@ pub async fn start_services(config: Config) -> Result<()> {
         SchedulerService::new(db_service.clone(), config.remote_builders).await?;
     let (eval_sender, eval_receiver) = channel::<EvalTask>(1000);
 
-    let web_service = WebService::bind_to_address(&config.web.address)
-        .await
-        .context("failed to start web service")?;
-
-    let maybe_github_service = match github::register_app().await {
+    let (maybe_github_service, octocrab_for_web) = match github::register_app().await {
         Ok(octocrab) => {
-            let github_service = GitHubService::new(db_service.clone(), octocrab).await?;
-            Some(github_service)
+            let github_service = GitHubService::new(db_service.clone(), octocrab.clone()).await?;
+            (Some(github_service), Some(octocrab))
         },
         Err(e) => {
             // In dev environments, there usually is no authentication, but the server should still
@@ -52,9 +48,13 @@ pub async fn start_services(config: Config) -> Result<()> {
             } else {
                 Err(e).context("failed to register GitHub app")?;
             }
-            None
+            (None, None)
         },
     };
+
+    let web_service = WebService::bind_to_address(&config.web.address, octocrab_for_web)
+        .await
+        .context("failed to start web service")?;
 
     let eval_service = EvalService::new(
         eval_receiver,

--- a/backend/server/src/web.rs
+++ b/backend/server/src/web.rs
@@ -2,8 +2,9 @@ use std::net::{SocketAddr, SocketAddrV4};
 
 use anyhow::{Context, Result};
 use axum::Router;
-use axum::extract::Json;
+use axum::extract::{Json, State};
 use axum::routing::{get, post};
+use octocrab::Octocrab;
 use octocrab::models::webhook_events::WebhookEventPayload as WEP;
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
@@ -11,15 +12,19 @@ use tracing::{error, info};
 
 pub struct WebService {
     listener: TcpListener,
+    octocrab: Option<Octocrab>,
 }
 
 impl WebService {
-    pub async fn bind_to_address(socket: &SocketAddrV4) -> Result<Self> {
+    pub async fn bind_to_address(
+        socket: &SocketAddrV4,
+        octocrab: Option<Octocrab>,
+    ) -> Result<Self> {
         let listener = tokio::net::TcpListener::bind(socket)
             .await
             .context(format!("failed to bind to tcp socket at {socket}"))?;
 
-        Ok(Self { listener })
+        Ok(Self { listener, octocrab })
     }
 
     pub fn bind_addr(&self) -> SocketAddr {
@@ -31,7 +36,9 @@ impl WebService {
     }
 
     pub async fn run(self, cancellation_token: CancellationToken) {
-        let app = Router::new().nest("/v1", api_routes());
+        let app = Router::new()
+            .nest("/v1", api_routes(self.octocrab.clone()))
+            .with_state(self.octocrab);
 
         if let Err(e) = axum::serve(self.listener, app)
             .with_graceful_shutdown(async move {
@@ -48,13 +55,20 @@ impl WebService {
     }
 }
 
-fn api_routes() -> Router {
-    Router::new()
-        .route("/logs/{drv}", get(get_derivation_log))
-        .route("/github/webhook", post(handle_github_webhook))
+fn api_routes(maybe_octocrab: Option<Octocrab>) -> Router<Option<Octocrab>> {
+    let mut router = Router::new().route("/logs/{drv}", get(get_derivation_log));
+
+    if maybe_octocrab.is_some() {
+        router = router.route("/github/webhook", post(handle_github_webhook));
+    }
+
+    router
 }
 
-async fn handle_github_webhook(Json(webhook_payload): Json<WEP>) {
+async fn handle_github_webhook(
+    State(_octocrab): State<Option<Octocrab>>,
+    Json(webhook_payload): Json<WEP>,
+) {
     crate::github::handle_webhook_payload(webhook_payload).await;
 }
 


### PR DESCRIPTION
This was in an attempt to support private github instances where checkouts of the repository will need a token. However, this turned into more of an endeavor than first through, so just going to punt on this for now.

Still going to merge the parts which will likely be needed in the future regardless.