### PR TITLE
Update readme for reduced feature set

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -9,6 +9,17 @@ The EkaCI tool will provide two "interfaces". One as a CI/CD tool which can emit
 PR check information. The other interface will be a web SPA which acts as review
 portal for maintainers to easily review PRs.
 
+## EkaCI, Conceptual design
+
+EkaCI works by creating a global addressed space for visted Nix derivations. These
+derivations are treated as unique builds across all repositories or time. This allows
+us to "cache" build results of a drv without having to associate with a particular
+commit, repository or package.
+
+EkaCI is designed to be an actor-based service, generally there is an actor ("service")
+per responsibility. This allows for good asynchronosity of logic flow, especially
+when much of the business logic is event based (e.g. webhooks, builds, gates, etc).
+
 ## EkaCI, the CI experience
 
 "As a PR Author, I would like to be informed as to when my PR fails eval, its build, or causes regressions"

--- a/README.md
+++ b/README.md
@@ -22,21 +22,26 @@ This doesn't scale well, and is error prone.
 See the [design document](./DESIGN.md) for details about a high-level overview
 of EkaCI.
 
-# MVP Roadmap
+# MVP Roadmap (Corepkgs bootstrapping usage)
 
 Server + evaluator + build queue
 
-- GitHub OAuth
-  - [ ] Allow users to register through GitHub
-- GitHub webhooks
+- GitHub 
   - [x] App registration workflow
-  - [ ] Receive PR review events
+  - [ ] Receive PR review events through webhooks
   - [x] Send check gates
 - PR Review workflow
   - [x] Git checkout
   - [x] Evaluate derivation differences between head and base branch
   - [x] Queue changed derivations for build
-  - [ ] Allow successful builds to push outputs to attic
+
+# Beta (Public Corepkgs usage)
+
+Backend
+- GitHub OAuth
+  - [ ] Allow users to register through GitHub
+- PR Checks
+  - [ ] Allow successful builds to push to a cache
   - [ ] Calculate changed metrics between builds: build and runtime closure size, dependencies
 - Push built artifacts
   - [ ] Allow for a time-lease to be configured for "jobsets", to enable attic integration


### PR DESCRIPTION
Move Oauth and cache pushing to beta. For bootstrapping I'm just going to be using the same build server to do ekaci and host the cache.