### PR TITLE
Add retry failed logic

### DIFF
--- a/backend/server/src/db/github.rs
+++ b/backend/server/src/db/github.rs
@@ -405,13 +405,13 @@ pub async fn get_job_info_for_drv(
 /// Terminal states are: Completed (success or failure), TransitiveFailure, and Interrupted states
 pub async fn all_jobs_concluded(jobset_id: i64, pool: &Pool<Sqlite>) -> anyhow::Result<bool> {
     // Query for jobs that are NOT in terminal states
-    // Non-terminal states: Queued (0), Buildable (1), Building (7), Blocked (100)
+    // Non-terminal states: Queued (0), Buildable (1), FailedRetry (2), Building (7), Blocked (100)
     let non_terminal_count: i64 = sqlx::query_scalar(
         r#"
         SELECT COUNT(*)
         FROM Job j
         JOIN Drv d ON j.drv_id = d.ROWID
-        WHERE j.jobset = ? AND d.build_state IN (0, 1, 7, 100)
+        WHERE j.jobset = ? AND d.build_state IN (0, 1, 2, 7, 100)
         "#,
     )
     .bind(jobset_id)

--- a/backend/server/src/db/service.rs
+++ b/backend/server/src/db/service.rs
@@ -67,6 +67,26 @@ impl DbService {
         drv::drv_referrers(&self.pool, drv).await
     }
 
+    pub async fn get_all_transitive_referrers(&self, drv: &DrvId) -> anyhow::Result<Vec<DrvId>> {
+        drv::get_all_transitive_referrers(drv, &self.pool).await
+    }
+
+    pub async fn insert_transitive_failures(
+        &self,
+        failed_drv: &DrvId,
+        transitive_referrers: &[DrvId],
+    ) -> anyhow::Result<()> {
+        drv::insert_transitive_failures(failed_drv, transitive_referrers, &self.pool).await
+    }
+
+    pub async fn clear_transitive_failures(&self, drv: &DrvId) -> anyhow::Result<Vec<DrvId>> {
+        drv::clear_transitive_failures(drv, &self.pool).await
+    }
+
+    pub async fn get_failed_dependencies(&self, drv: &DrvId) -> anyhow::Result<Vec<DrvId>> {
+        drv::get_failed_dependencies(drv, &self.pool).await
+    }
+
     pub async fn insert_drvs_and_references(
         &self,
         drvs: &[Drv],
@@ -102,7 +122,7 @@ impl DbService {
     }
 
     pub async fn get_buildable_drvs(&self) -> anyhow::Result<Vec<DrvId>> {
-        drv::get_derivations_in_state(build_event::DrvBuildState::Buildable, &self.pool).await
+        drv::get_buildable_and_retry_drvs(&self.pool).await
     }
 
     pub async fn create_github_jobset_with_jobs(
@@ -186,28 +206,5 @@ impl DbService {
 
     pub async fn get_jobset_info(&self, jobset_id: i64) -> anyhow::Result<github::JobSetInfo> {
         github::get_jobset_info(jobset_id, &self.pool).await
-    }
-
-    pub async fn get_all_transitive_referrers(&self, drv: &DrvId) -> anyhow::Result<Vec<DrvId>> {
-        drv::get_all_transitive_referrers(drv, &self.pool).await
-    }
-
-    pub async fn insert_transitive_failures(
-        &self,
-        failed_drv: &DrvId,
-        transitive_referrers: &[DrvId],
-    ) -> anyhow::Result<()> {
-        drv::insert_transitive_failures(failed_drv, transitive_referrers, &self.pool).await
-    }
-
-    pub async fn clear_transitive_failures(
-        &self,
-        failed_drv: &DrvId,
-    ) -> anyhow::Result<Vec<DrvId>> {
-        drv::clear_transitive_failures(failed_drv, &self.pool).await
-    }
-
-    pub async fn get_failed_dependencies(&self, drv: &DrvId) -> anyhow::Result<Vec<DrvId>> {
-        drv::get_failed_dependencies(drv, &self.pool).await
     }
 }


### PR DESCRIPTION
We should attempt to rebuild a package after first failure to help mitigate against transient failures.

Eventually, I would like to have the rescheduled job to be enqueued on a different builder, but for now just try a second time.