### PR TITLE
WIP: Implement imperative commands

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -206,6 +206,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
+name = "birdcage"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "848df95320021558dd6bb4c26de3fe66724cdcbdbbf3fa720150b52b086ae568"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+ "log",
+ "rustix 0.38.44",
+ "seccompiler",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +515,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "birdcage",
  "bstr",
  "chrono",
  "clap",
@@ -522,6 +536,7 @@ dependencies = [
  "serde_json",
  "shared",
  "sqlx",
+ "tempfile",
  "thiserror 2.0.17",
  "tokio",
  "tokio-util",
@@ -2198,7 +2213,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2327,6 +2342,15 @@ checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "seccompiler"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f6575e3c2b3a0fe2ef3e53855b6a8dead7c29f783da5e123d378c8c6a89017e"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/backend/server/Cargo.toml
+++ b/backend/server/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/ekala-project/eka-ci"
 anyhow = { workspace = true }
 async-trait = "0.1"
 axum = { version = "0.8.3", features = ["tokio", "tracing", "json"] }
+birdcage = "0.8.1"
 bstr = "1.12.0"
 chrono = { version = "0.4.40", default-features = false, features = ["now", "std"] }
 clap = { workspace = true }
@@ -29,6 +30,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 shared = { workspace = true }
 sqlx = { version = "0.8.5", features = [ "runtime-tokio", "sqlite", "migrate", "macros", "chrono" ], default-features = false }
+tempfile = "3.14"
 thiserror = { workspace = true }
 tokio = { version = "1.41.0", features = ["full"] }
 tokio-util = "0.7.15"

--- a/backend/server/sql/migrations/20260212_checks.sql
+++ b/backend/server/sql/migrations/20260212_checks.sql
@@ -1,0 +1,61 @@
+-- Checks are similar to jobs but execute sandboxed imperative commands
+-- instead of evaluating Nix expressions. Each PR can have multiple checks
+-- that run commands in a sandboxed checkout of the repository.
+
+-- CheckSets track which checks were run for a specific commit
+CREATE TABLE IF NOT EXISTS GitHubCheckSets (
+    ROWID INTEGER PRIMARY KEY,
+    -- this is the git commit, github uses sha as the name
+    sha TEXT NOT NULL,
+    -- "check name". Used to identify the check
+    check_name TEXT NOT NULL,
+    -- repository owner, e.g. github.com/{owner}/{repo}
+    owner TEXT NOT NULL,
+    -- repository name, e.g. github.com/{owner}/{repo}
+    repo_name TEXT NOT NULL,
+    UNIQUE (sha, check_name) ON CONFLICT IGNORE
+);
+
+-- Index for querying checks by sha
+CREATE INDEX IF NOT EXISTS CheckSetSha ON GitHubCheckSets (sha);
+CREATE INDEX IF NOT EXISTS CheckSetName ON GitHubCheckSets (check_name);
+
+-- CheckResults store the output of each check execution
+CREATE TABLE IF NOT EXISTS CheckResult (
+    ROWID INTEGER PRIMARY KEY,
+    checkset INTEGER NOT NULL, -- identifier for a specific check on a commit
+    success BOOLEAN NOT NULL, -- whether the check passed
+    exit_code INTEGER NOT NULL, -- exit code from the command
+    stdout TEXT, -- standard output (may be truncated)
+    stderr TEXT, -- standard error (may be truncated)
+    duration_ms INTEGER NOT NULL, -- execution time in milliseconds
+    executed_at INTEGER NOT NULL, -- unix timestamp when check was executed
+    FOREIGN KEY (checkset) REFERENCES GitHubCheckSets(ROWID) ON DELETE CASCADE
+);
+
+-- Index for querying results by checkset
+CREATE INDEX IF NOT EXISTS CheckResultCheckSet ON CheckResult (checkset);
+CREATE INDEX IF NOT EXISTS CheckResultSuccess ON CheckResult (checkset, success);
+
+-- CheckRunInfo links GitHub check_run IDs to check results
+-- This is similar to how derivation builds are tracked for jobs
+CREATE TABLE IF NOT EXISTS CheckRunInfo (
+    check_run_id INTEGER PRIMARY KEY, -- GitHub check_run ID
+    check_result_id INTEGER NOT NULL, -- reference to CheckResult
+    repo_name TEXT NOT NULL,
+    repo_owner TEXT NOT NULL,
+    FOREIGN KEY (check_result_id) REFERENCES CheckResult(ROWID) ON DELETE CASCADE
+);
+
+-- View for easily querying check run status
+CREATE VIEW IF NOT EXISTS CheckRun AS
+SELECT
+    c.check_run_id,
+    c.repo_name,
+    c.repo_owner,
+    r.success,
+    r.exit_code,
+    r.duration_ms,
+    r.executed_at
+FROM CheckRunInfo AS c
+JOIN CheckResult AS r ON r.ROWID = c.check_result_id;

--- a/backend/server/src/checks/executor.rs
+++ b/backend/server/src/checks/executor.rs
@@ -1,0 +1,388 @@
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use anyhow::{Context, Result};
+use birdcage::process::Command;
+use birdcage::{Birdcage, Exception, Sandbox};
+use tracing::{debug, info};
+
+use super::{CheckResult, parse_env_output};
+use crate::ci::config::Check;
+
+/// Execute a check in a sandboxed environment
+///
+/// This function:
+/// 1. Creates a temporary checkout directory
+/// 2. Gets the nix shell environment (from flake or shell.nix)
+/// 3. Creates a birdcage sandbox with appropriate mounts
+/// 4. Executes the command in the sandboxed checkout
+pub async fn execute_check(
+    check: &Check,
+    repo_path: &Path,
+    check_name: &str,
+) -> Result<CheckResult> {
+    info!("Executing check: {}", check_name);
+
+    // Step 1: Create temporary directory for checkout
+    let temp_dir = tempfile::tempdir().context("Failed to create temp directory")?;
+    let checkout_path = temp_dir.path();
+
+    // Copy repository to temp directory
+    copy_repository(repo_path, checkout_path).await?;
+
+    // Step 2: Get nix shell environment
+    debug!(
+        "Fetching nix shell environment (shell: {:?}, shell_nix: {})",
+        check.shell, check.shell_nix
+    );
+    let env_vars =
+        get_nix_shell_env(check.shell.as_deref(), check.shell_nix, checkout_path).await?;
+
+    // Step 3 & 4: Execute in sandbox
+    let start = Instant::now();
+    let result = execute_in_sandbox(
+        checkout_path,
+        &check.command,
+        &env_vars,
+        check.allow_network,
+    )?;
+    let duration_ms = start.elapsed().as_millis() as u64;
+
+    info!(
+        "Check {} completed in {}ms with exit code {}",
+        check_name, duration_ms, result.exit_code
+    );
+
+    Ok(CheckResult::new(
+        result.exit_code == 0,
+        result.exit_code,
+        result.stdout,
+        result.stderr,
+        duration_ms,
+    ))
+}
+
+/// Copy repository contents to a temporary directory
+async fn copy_repository(src: &Path, dst: &Path) -> Result<()> {
+    debug!(
+        "Copying repository from {} to {}",
+        src.display(),
+        dst.display()
+    );
+
+    // Use tokio to spawn blocking copy operation
+    let src = src.to_path_buf();
+    let dst = dst.to_path_buf();
+
+    tokio::task::spawn_blocking(move || copy_dir_all(&src, &dst))
+        .await
+        .context("Failed to spawn copy task")?
+        .context("Failed to copy repository")?;
+
+    Ok(())
+}
+
+/// Recursively copy a directory
+fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+
+        if ty.is_dir() {
+            // Skip common directories that don't need to be checked
+            let dir_name = entry.file_name();
+            if dir_name == ".git" || dir_name == "target" || dir_name == "node_modules" {
+                continue;
+            }
+            copy_dir_all(&src_path, &dst_path)?;
+        } else {
+            std::fs::copy(src_path, dst_path)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Get environment variables from nix shell (either flake or shell.nix)
+async fn get_nix_shell_env(
+    shell: Option<&str>,
+    shell_nix: bool,
+    checkout_path: &Path,
+) -> Result<std::collections::HashMap<String, String>> {
+    use std::process::Stdio;
+
+    if shell_nix {
+        // shell.nix mode
+        let shell_nix_path = checkout_path.join("shell.nix");
+        if !shell_nix_path.exists() {
+            anyhow::bail!(
+                "No shell.nix found in repository. When shell_nix is true, a shell.nix file is \
+                 required. Please add shell.nix or set shell_nix to false."
+            );
+        }
+
+        debug!(
+            "Running nix-shell shell.nix{} --run env",
+            shell.map(|s| format!(" -A {}", s)).unwrap_or_default()
+        );
+
+        let mut cmd = tokio::process::Command::new("nix-shell");
+        cmd.env_clear().current_dir(checkout_path).arg("shell.nix");
+
+        if let Some(shell_name) = shell {
+            cmd.arg("-A").arg(shell_name);
+        }
+
+        cmd.arg("--run")
+            .arg("env")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let output = cmd.output().await.context("Failed to execute nix-shell")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("nix-shell failed: {}", stderr);
+        }
+
+        let stdout = String::from_utf8(output.stdout)
+            .context("Failed to parse nix-shell output as UTF-8")?;
+
+        Ok(parse_env_output(&stdout))
+    } else {
+        // flake mode
+        let flake_path = checkout_path.join("flake.nix");
+        if !flake_path.exists() {
+            anyhow::bail!(
+                "No flake.nix found in repository. The checks feature requires a flake.nix file. \
+                 Please add a flake.nix with devShells or set shell_nix to true to use shell.nix."
+            );
+        }
+
+        // Build the flake reference
+        let flake_ref = match shell {
+            Some(shell_name) => format!(".#{}", shell_name),
+            None => ".".to_string(),
+        };
+
+        debug!("Running nix develop {} --command env", flake_ref);
+
+        let output = tokio::process::Command::new("nix")
+            .env_clear() // Start with empty environment
+            .current_dir(checkout_path) // Run in the checkout directory
+            .arg("develop")
+            .arg(&flake_ref)
+            .arg("--command")
+            .arg("env")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .await
+            .context("Failed to execute nix develop")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("nix develop failed: {}", stderr);
+        }
+
+        let stdout = String::from_utf8(output.stdout)
+            .context("Failed to parse nix develop output as UTF-8")?;
+
+        Ok(parse_env_output(&stdout))
+    }
+}
+
+struct CommandResult {
+    exit_code: i32,
+    stdout: String,
+    stderr: String,
+}
+
+/// Execute command in birdcage sandbox
+fn execute_in_sandbox(
+    checkout_path: &Path,
+    command: &str,
+    env_vars: &std::collections::HashMap<String, String>,
+    allow_network: bool,
+) -> Result<CommandResult> {
+    use birdcage::process::Stdio;
+
+    debug!("Setting up birdcage sandbox at {}", checkout_path.display());
+
+    let mut sandbox = Birdcage::new();
+
+    // Mount /nix/store as read-only
+    sandbox
+        .add_exception(Exception::Read(PathBuf::from("/nix/store")))
+        .context("Failed to add /nix/store read exception")?;
+
+    // Mount checkout directory as read-write
+    sandbox
+        .add_exception(Exception::WriteAndRead(checkout_path.to_path_buf()))
+        .context("Failed to add checkout path write exception")?;
+
+    // Mount .git directory as read-only (inside checkout)
+    let git_dir = checkout_path.join(".git");
+    if git_dir.exists() {
+        sandbox
+            .add_exception(Exception::Read(git_dir))
+            .context("Failed to add .git read exception")?;
+    }
+
+    // Disable network if requested
+    if !allow_network {
+        sandbox
+            .add_exception(Exception::Networking)
+            .context("Failed to disable networking")?;
+    }
+
+    debug!("Executing command: {}", command);
+
+    // Build the command with environment variables and directory change
+    // We need to export all environment variables and cd to the checkout path
+    let mut script = String::new();
+    for (key, value) in env_vars {
+        // Escape single quotes in values
+        let escaped_value = value.replace("'", "'\\''");
+        script.push_str(&format!("export {}='{}'\n", key, escaped_value));
+    }
+    script.push_str(&format!("cd '{}'\n", checkout_path.display()));
+    script.push_str(command);
+
+    // Execute command with sh -c using sandbox.spawn()
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c")
+        .arg(&script)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let output = sandbox
+        .spawn(cmd)
+        .context("Failed to spawn command in sandbox")?
+        .wait_with_output()
+        .context("Failed to wait for command output")?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let exit_code = output.status.code().unwrap_or(-1);
+
+    Ok(CommandResult {
+        exit_code,
+        stdout,
+        stderr,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    #[tokio::test]
+    #[ignore] // Requires nix develop to be available and a flake.nix
+    async fn test_get_nix_shell_env_flake() {
+        // This test requires a repository with a flake.nix
+        // Create a temporary directory with a minimal flake
+        let temp_dir = tempfile::tempdir().unwrap();
+        let flake_content = r#"{
+  description = "Test flake";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  outputs = { nixpkgs, ... }: {
+    devShells.x86_64-linux.default = nixpkgs.legacyPackages.x86_64-linux.mkShell {
+      packages = [ nixpkgs.legacyPackages.x86_64-linux.hello ];
+    };
+  };
+}"#;
+        fs::write(temp_dir.path().join("flake.nix"), flake_content).unwrap();
+
+        let env = get_nix_shell_env(None, false, temp_dir.path()).await;
+
+        // Should succeed if nix is installed
+        if let Ok(env_vars) = env {
+            assert!(env_vars.contains_key("PATH"));
+            // PATH should contain a /nix/store path
+            let path = env_vars.get("PATH").unwrap();
+            assert!(path.contains("/nix/store"));
+        }
+    }
+
+    #[tokio::test]
+    #[ignore] // Requires nix develop and creates temporary files
+    async fn test_execute_check_basic() {
+        // Create a temporary directory with a simple test file and flake
+        let temp_dir = tempfile::tempdir().unwrap();
+        let test_file = temp_dir.path().join("test.txt");
+        fs::write(&test_file, "test content").unwrap();
+
+        // Create a minimal flake.nix
+        let flake_content = r#"{
+  description = "Test flake";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  outputs = { nixpkgs, ... }: {
+    devShells.x86_64-linux.default = nixpkgs.legacyPackages.x86_64-linux.mkShell {
+      packages = [ nixpkgs.legacyPackages.x86_64-linux.coreutils ];
+    };
+  };
+}"#;
+        fs::write(temp_dir.path().join("flake.nix"), flake_content).unwrap();
+
+        // Create a check that reads the file
+        let check = Check {
+            shell: None,
+            shell_nix: false,
+            command: "cat test.txt".to_string(),
+            allow_network: false,
+        };
+
+        // Execute the check
+        let result = execute_check(&check, temp_dir.path(), "test-check").await;
+
+        // Verify the result
+        assert!(result.is_ok());
+        let check_result = result.unwrap();
+        assert!(check_result.success);
+        assert_eq!(check_result.exit_code, 0);
+        assert!(check_result.stdout.contains("test content"));
+    }
+
+    #[tokio::test]
+    #[ignore] // Requires nix develop
+    async fn test_execute_check_failure() {
+        // Create a temporary directory
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        // Create a minimal flake.nix
+        let flake_content = r#"{
+  description = "Test flake";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  outputs = { nixpkgs, ... }: {
+    devShells.x86_64-linux.default = nixpkgs.legacyPackages.x86_64-linux.mkShell {
+      packages = [ nixpkgs.legacyPackages.x86_64-linux.coreutils ];
+    };
+  };
+}"#;
+        fs::write(temp_dir.path().join("flake.nix"), flake_content).unwrap();
+
+        // Create a check that will fail
+        let check = Check {
+            shell: None,
+            shell_nix: false,
+            command: "cat nonexistent-file.txt".to_string(),
+            allow_network: false,
+        };
+
+        // Execute the check
+        let result = execute_check(&check, temp_dir.path(), "failing-check").await;
+
+        // Verify the result indicates failure
+        assert!(result.is_ok());
+        let check_result = result.unwrap();
+        assert!(!check_result.success);
+        assert_ne!(check_result.exit_code, 0);
+    }
+}

--- a/backend/server/src/checks/mod.rs
+++ b/backend/server/src/checks/mod.rs
@@ -1,0 +1,63 @@
+pub mod executor;
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckResult {
+    pub success: bool,
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+    pub duration_ms: u64,
+}
+
+impl CheckResult {
+    pub fn new(
+        success: bool,
+        exit_code: i32,
+        stdout: String,
+        stderr: String,
+        duration_ms: u64,
+    ) -> Self {
+        Self {
+            success,
+            exit_code,
+            stdout,
+            stderr,
+            duration_ms,
+        }
+    }
+}
+
+/// Parse environment variables from the output of `nix-shell --run 'env'`
+pub fn parse_env_output(output: &str) -> HashMap<String, String> {
+    let mut env_vars = HashMap::new();
+
+    for line in output.lines() {
+        if let Some((key, value)) = line.split_once('=') {
+            env_vars.insert(key.to_string(), value.to_string());
+        }
+    }
+
+    env_vars
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_env_output() {
+        let output = "PATH=/nix/store/abc-hello/bin:/usr/bin\nHOME=/home/user\nFOO=bar";
+        let env = parse_env_output(output);
+
+        assert_eq!(
+            env.get("PATH"),
+            Some(&"/nix/store/abc-hello/bin:/usr/bin".to_string())
+        );
+        assert_eq!(env.get("HOME"), Some(&"/home/user".to_string()));
+        assert_eq!(env.get("FOO"), Some(&"bar".to_string()));
+    }
+}

--- a/backend/server/src/ci/config.rs
+++ b/backend/server/src/ci/config.rs
@@ -7,6 +7,10 @@ fn default_true() -> bool {
     true
 }
 
+fn default_false() -> bool {
+    false
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Job {
     pub file: PathBuf,
@@ -15,8 +19,32 @@ pub struct Job {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+pub struct Check {
+    /// Optional shell name
+    /// - When shell_nix=false: maps to flake devShells (e.g., "foo" → `nix develop .#foo`)
+    /// - When shell_nix=true: maps to shell.nix attribute (e.g., "foo" → `nix-shell shell.nix -A
+    ///   foo`)
+    /// - If not specified: uses default shell
+    #[serde(default)]
+    pub shell: Option<String>,
+    /// Whether to use shell.nix instead of flake devShells
+    /// - false (default): use `nix develop` with flake.nix
+    /// - true: use `nix-shell` with shell.nix
+    #[serde(default = "default_false")]
+    pub shell_nix: bool,
+    /// Command to execute in the sandboxed checkout
+    pub command: String,
+    /// Whether to allow network access in the sandbox
+    #[serde(default = "default_false")]
+    pub allow_network: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 pub struct CIConfig {
+    #[serde(default)]
     pub jobs: HashMap<String, Job>,
+    #[serde(default)]
+    pub checks: HashMap<String, Check>,
 }
 
 impl CIConfig {
@@ -41,5 +69,45 @@ mod tests {
 }"#;
         serde_json::from_str::<CIConfig>(example_config)
             .expect("Failed to deserialize example config");
+    }
+
+    #[test]
+    fn test_deserialization_with_checks() {
+        let example_config = r#"{
+  "jobs": {
+    "stdenv": {
+      "file": "../stdenv.nix",
+      "allow-eval-failures": false
+    }
+  },
+  "checks": {
+    "nixfmt": {
+      "shell": "formatting",
+      "command": "nixfmt --check **/*.nix",
+      "allow_network": false
+    },
+    "cargo-test": {
+      "command": "cargo test --workspace",
+      "allow_network": true
+    }
+  }
+}"#;
+        let config = serde_json::from_str::<CIConfig>(example_config)
+            .expect("Failed to deserialize example config with checks");
+
+        assert_eq!(config.checks.len(), 2);
+        assert!(config.checks.contains_key("nixfmt"));
+        assert!(config.checks.contains_key("cargo-test"));
+
+        // Verify shell field
+        assert_eq!(
+            config.checks.get("nixfmt").unwrap().shell,
+            Some("formatting".to_string())
+        );
+        assert_eq!(config.checks.get("cargo-test").unwrap().shell, None);
+
+        // Verify shell_nix defaults to false
+        assert_eq!(config.checks.get("nixfmt").unwrap().shell_nix, false);
+        assert_eq!(config.checks.get("cargo-test").unwrap().shell_nix, false);
     }
 }

--- a/backend/server/src/ci/mod.rs
+++ b/backend/server/src/ci/mod.rs
@@ -1,4 +1,4 @@
-mod config;
+pub mod config;
 
 use std::path::PathBuf;
 

--- a/backend/server/src/main.rs
+++ b/backend/server/src/main.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod checks;
 mod ci;
 mod client;
 mod config;

--- a/examples/checks_example/.ekaci/config.json
+++ b/examples/checks_example/.ekaci/config.json
@@ -1,0 +1,18 @@
+{
+  "checks": {
+    "nixfmt": {
+      "shell": "formatting",
+      "command": "nixfmt --check **/*.nix",
+      "allow_network": false
+    },
+    "echo-test": {
+      "command": "echo 'Hello from sandboxed check!'",
+      "allow_network": false
+    },
+    "network-test": {
+      "shell": "networking",
+      "command": "curl -I https://example.com",
+      "allow_network": true
+    }
+  }
+}

--- a/examples/checks_example/README.md
+++ b/examples/checks_example/README.md
@@ -1,0 +1,83 @@
+# Checks Example
+
+This example demonstrates the new "checks" feature in eka-ci, which allows running sandboxed imperative commands on repository checkouts.
+
+## Overview
+
+Unlike "jobs" which evaluate Nix expressions to produce derivations, "checks" execute commands in a sandboxed environment with specific packages available. This is similar to GitHub Actions workflows but with enhanced security through sandboxing.
+
+## Configuration
+
+Checks are defined in `.ekaci/config.json`:
+
+```json
+{
+  "checks": {
+    "nixfmt": {
+      "shell": "formatting",
+      "command": "nixfmt --check **/*.nix",
+      "allow_network": false
+    },
+    "echo-test": {
+      "command": "echo 'Hello from sandboxed check!'",
+      "allow_network": false
+    },
+    "network-test": {
+      "shell": "networking",
+      "command": "curl -I https://example.com",
+      "allow_network": true
+    }
+  }
+}
+```
+
+### Check Configuration Fields
+
+- **shell**: Optional name of the shell environment to use
+  - When `shell_nix` is false (default): References a flake devShell (e.g., "formatting" → `nix develop .#formatting`)
+  - When `shell_nix` is true: References a shell.nix attribute (e.g., "myEnv" → `nix-shell shell.nix -A myEnv`)
+  - If omitted: Uses default shell (`nix develop .` or `nix-shell shell.nix`)
+- **shell_nix**: Boolean flag to use shell.nix instead of flake.nix (default: false)
+  - `false`: Use `nix develop` with flake.nix (recommended for new projects)
+  - `true`: Use `nix-shell` with shell.nix (for legacy compatibility)
+- **command**: Shell command to execute in the sandboxed checkout
+- **allow_network**: Boolean flag to enable/disable network access (default: false)
+
+## How It Works
+
+1. **Environment Setup**: The system obtains the Nix environment in one of two ways:
+   - **Flake mode** (default): Runs `nix develop .#<shell> --command env` to get the devShell environment from flake.nix
+   - **shell.nix mode**: Runs `nix-shell shell.nix -A <shell> --run env` to get the environment from shell.nix
+2. **Repository Checkout**: A temporary copy of the repository is created
+3. **Sandbox Creation**: Using birdcage, a sandbox is created with:
+   - Read-only access to `/nix/store`
+   - Read-write access to the checkout directory
+   - Read-only access to `.git` directory
+   - Optional network access
+4. **Command Execution**: The command runs in the sandbox with the Nix environment
+5. **Result Capture**: Exit code, stdout, stderr, and duration are recorded
+
+## Security Features
+
+- **Isolated Filesystem**: Commands can only access the checkout and `/nix/store`
+- **Network Control**: Network access can be disabled per-check
+- **No Nix Daemon**: The sandbox doesn't have access to the Nix daemon
+- **Ephemeral Execution**: The checkout is discarded after the check completes
+
+## Use Cases
+
+- **Formatters**: `nixfmt`, `rustfmt`, `prettier`
+- **Linters**: `statix`, `clippy`, `eslint`
+- **Tests**: `cargo test`, `pytest`, `npm test`
+- **Security Scans**: `cargo audit`, `npm audit`
+- **Custom Scripts**: Any command that can be packaged with Nix
+
+## Comparison with Jobs
+
+| Feature | Jobs | Checks |
+|---------|------|--------|
+| Purpose | Build Nix derivations | Run imperative commands |
+| Evaluation | Pure Nix evaluation | Sandboxed command execution |
+| Caching | Nix store caching | No caching |
+| Network | Depends on derivation | Configurable per-check |
+| Use Case | Package builds | Linting, formatting, testing |

--- a/examples/checks_example/example.nix
+++ b/examples/checks_example/example.nix
@@ -1,0 +1,7 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+
+{
+  hello = pkgs.hello;
+}

--- a/examples/checks_example/flake.nix
+++ b/examples/checks_example/flake.nix
@@ -1,0 +1,38 @@
+{
+  description = "Example flake for eka-ci checks";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+    in
+    {
+      devShells.${system} = {
+        # Default dev shell with basic tools
+        default = pkgs.mkShell {
+          packages = with pkgs; [
+            coreutils
+          ];
+        };
+
+        # Dev shell for formatting checks
+        formatting = pkgs.mkShell {
+          packages = with pkgs; [
+            nixfmt-rfc-style
+          ];
+        };
+
+        # Dev shell for network checks
+        networking = pkgs.mkShell {
+          packages = with pkgs; [
+            curl
+          ];
+        };
+      };
+    };
+}

--- a/examples/checks_example/shell.nix
+++ b/examples/checks_example/shell.nix
@@ -1,0 +1,23 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+
+{
+  default = pkgs.mkShell {
+    packages = with pkgs; [
+      coreutils
+    ];
+  };
+
+  formatting = pkgs.mkShell {
+    packages = with pkgs; [
+      nixfmt-rfc-style
+    ];
+  };
+
+  networking = pkgs.mkShell {
+    packages = with pkgs; [
+      curl
+    ];
+  };
+}


### PR DESCRIPTION
Try to make an imperative abstraction for doing CI tasks.

Current things which I don't like:
- ~~drv evaluation, currently uses `nix-shell` which then uses `<nixpkgs>` to get the packages, we should probably allow for dev shells (either flake or shell.nix)~~
  - ~~Likely will change this to use a flake devshell, or `shell.nix`~~