### PR TITLE
Check substitution status first

### DIFF
--- a/backend/server/src/nix/mod.rs
+++ b/backend/server/src/nix/mod.rs
@@ -3,9 +3,10 @@ pub mod jobs;
 pub mod nix_eval_jobs;
 pub mod size;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use lru::LruCache;
@@ -284,9 +285,141 @@ impl EvalService {
     }
 }
 
+/// Result of a `nix-store --realise --dry-run` invocation against a derivation.
+///
+/// Nix prints two relevant sections to stderr:
+/// * `(this|these N) derivation(s) will be built:` followed by indented `.drv` paths that are NOT
+///   available locally and CANNOT be substituted from any configured binary cache — i.e. they would
+///   actually need to run.
+/// * `(this|these N) path(s) will be fetched (...)` followed by indented store output paths that
+///   are not in the local store but ARE available from a binary cache.
+///
+/// Anything not mentioned in either section is already valid in the local store.
+///
+/// We treat a derivation as "cached" iff its `.drv` path does not appear in
+/// `will_build` — meaning it is either already built locally OR pullable from
+/// a substituter, both of which mean we don't need to run a real build.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DryRunReport {
+    /// Full store paths (`/nix/store/...drv`) that nix says still need building.
+    pub will_build: HashSet<String>,
+    /// Full store paths (`/nix/store/...`) that nix says will be substituted.
+    pub will_fetch: HashSet<String>,
+}
+
+impl DryRunReport {
+    /// Parse the stderr emitted by `nix-store --realise --dry-run`.
+    ///
+    /// The format is fairly stable across modern Nix versions; we tolerate
+    /// minor variations (singular vs. plural section headers, optional
+    /// download-size annotations, leading whitespace differences).
+    pub fn parse(stderr: &str) -> Self {
+        #[derive(Clone, Copy)]
+        enum Section {
+            Build,
+            Fetch,
+        }
+
+        let mut report = DryRunReport::default();
+        let mut current: Option<Section> = None;
+
+        for raw_line in stderr.lines() {
+            // Identify section headers regardless of pluralization. Nix emits
+            // these without leading whitespace and ending with `:`.
+            let trimmed = raw_line.trim_end();
+            let lower = trimmed.trim_start().to_ascii_lowercase();
+
+            // Section headers start a new section. Order matters: check
+            // headers BEFORE treating an indented line as a path, because
+            // a header is never indented in practice but we trim defensively.
+            if !raw_line.starts_with(char::is_whitespace) {
+                if lower.contains("will be built") || lower.starts_with("don't know how to build") {
+                    current = Some(Section::Build);
+                    continue;
+                }
+                if lower.contains("will be fetched") {
+                    current = Some(Section::Fetch);
+                    continue;
+                }
+                // Any other unindented non-blank line ends the current section
+                // (e.g. warnings, the empty line nix prints between sections,
+                // the final summary line).
+                if !trimmed.is_empty() {
+                    current = None;
+                }
+                continue;
+            }
+
+            // Indented line — interpret as a path entry IF we're in a section.
+            let path = trimmed.trim();
+            if path.is_empty() {
+                continue;
+            }
+            // Only accept absolute store paths; ignore stray indented text.
+            if !path.starts_with('/') {
+                continue;
+            }
+            match current {
+                Some(Section::Build) => {
+                    report.will_build.insert(path.to_string());
+                },
+                Some(Section::Fetch) => {
+                    report.will_fetch.insert(path.to_string());
+                },
+                None => {},
+            }
+        }
+
+        report
+    }
+
+    /// True iff `drv` does not appear in `will_build` — i.e. its output is
+    /// either already in the local store or pullable from a substituter.
+    pub fn is_cached(&self, drv: &DrvId) -> bool {
+        !self.will_build.contains(&drv.store_path())
+    }
+}
+
+/// How long to wait for `nix-store --realise --dry-run` to complete before
+/// giving up. Substituter HTTP queries are the dominant cost; 30s comfortably
+/// covers a slow but reachable cache while still failing fast on a wedged one.
+const DRY_RUN_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Run `nix-store --realise --dry-run <drv>` and parse the result.
+///
+/// Returns `Err` for any I/O / process failure or non-zero exit so callers can
+/// safely fall back to a real build (substitution checks are an optimization,
+/// never a correctness requirement).
+pub async fn dry_run_realise(drv: &DrvId) -> Result<DryRunReport> {
+    let store_path = drv.store_path();
+    let output = tokio::time::timeout(
+        DRY_RUN_TIMEOUT,
+        Command::new("nix-store")
+            .args(["--realise", "--dry-run", &store_path])
+            .output(),
+    )
+    .await
+    .with_context(|| format!("nix-store --realise --dry-run timed out for {store_path}"))?
+    .with_context(|| format!("failed to spawn nix-store --realise --dry-run for {store_path}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "nix-store --realise --dry-run failed for {} (exit {:?}): {}",
+            store_path,
+            output.status.code(),
+            stderr.trim()
+        );
+    }
+
+    // Nix writes the build/fetch plan to stderr; stdout is empty under --dry-run.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    Ok(DryRunReport::parse(&stderr))
+}
+
 /// Retreive the requisites of a drv. This is a global list of all direct
 /// and transitive drvs
-async fn drv_requisites(drv_path: &str) -> Result<Vec<DrvId>> {
+pub(crate) async fn drv_requisites(drv_path: &str) -> Result<Vec<DrvId>> {
     use std::str::FromStr;
 
     let output = Command::new("nix-store")
@@ -469,3 +602,125 @@ pub async fn get_drv_outputs(drv_path: &str) -> Result<HashMap<String, String>> 
 //
 //     Ok(drvs)
 // }
+
+#[cfg(test)]
+mod dry_run_tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    fn drv(name: &str) -> DrvId {
+        // 32-char base32-only stub hash; the actual value is irrelevant — we
+        // only need a syntactically valid DrvId so we can call store_path().
+        DrvId::from_str(&format!("jd83l3jn2mkn530lgcg0y523jq5qji85-{name}.drv")).unwrap()
+    }
+
+    #[test]
+    fn parse_empty_means_already_built_locally() {
+        let report = DryRunReport::parse("");
+        assert!(report.will_build.is_empty());
+        assert!(report.will_fetch.is_empty());
+        assert!(report.is_cached(&drv("hello")));
+    }
+
+    #[test]
+    fn parse_will_be_built_singular() {
+        let stderr = "this derivation will be built:\n  /nix/store/aaa-foo.drv\n";
+        let report = DryRunReport::parse(stderr);
+        assert_eq!(report.will_build.len(), 1);
+        assert!(report.will_build.contains("/nix/store/aaa-foo.drv"));
+        assert!(report.will_fetch.is_empty());
+    }
+
+    #[test]
+    fn parse_will_be_built_plural_with_count() {
+        let stderr = "these 3 derivations will be built:\n  /nix/store/a-foo.drv\n  \
+                      /nix/store/b-bar.drv\n  /nix/store/c-baz.drv\n";
+        let report = DryRunReport::parse(stderr);
+        assert_eq!(report.will_build.len(), 3);
+    }
+
+    #[test]
+    fn parse_will_be_fetched_with_size_annotation() {
+        let stderr = "these 2 paths will be fetched (1.23 MiB download, 5.67 MiB unpacked):\n  \
+                      /nix/store/aaa-foo\n  /nix/store/bbb-bar\n";
+        let report = DryRunReport::parse(stderr);
+        assert!(report.will_build.is_empty());
+        assert_eq!(report.will_fetch.len(), 2);
+        assert!(report.will_fetch.contains("/nix/store/aaa-foo"));
+        assert!(report.will_fetch.contains("/nix/store/bbb-bar"));
+    }
+
+    #[test]
+    fn parse_mixed_sections() {
+        let stderr = "these 2 derivations will be built:\n  /nix/store/a-build.drv\n  \
+                      /nix/store/b-build.drv\nthese 1 paths will be fetched (1 KiB download):\n  \
+                      /nix/store/c-fetch\n";
+        let report = DryRunReport::parse(stderr);
+        assert_eq!(report.will_build.len(), 2);
+        assert_eq!(report.will_fetch.len(), 1);
+    }
+
+    #[test]
+    fn is_cached_uses_will_build_membership() {
+        // The drv we are checking is in will_build — NOT cached.
+        let target = drv("foo");
+        let stderr = format!(
+            "this derivation will be built:\n  {}\n",
+            target.store_path()
+        );
+        let report = DryRunReport::parse(&stderr);
+        assert!(!report.is_cached(&target));
+
+        // The drv is only in will_fetch (its OUTPUT is fetchable from cache).
+        // The .drv path itself is not in will_build, so we're "cached".
+        let report = DryRunReport::parse(
+            "these 1 paths will be fetched (1 KiB download):\n  /nix/store/aaa-foo\n",
+        );
+        assert!(report.is_cached(&target));
+    }
+
+    #[test]
+    fn parse_dont_know_how_to_build_treated_as_build() {
+        // When substitution is unavailable and the drv isn't in the local store,
+        // nix prints "don't know how to build the following paths:" — we treat
+        // these the same as "will be built" so the caller falls back to the
+        // normal build path (which will surface the error properly).
+        let stderr = "don't know how to build the following paths:\n  /nix/store/x-foo.drv\n";
+        let report = DryRunReport::parse(stderr);
+        assert_eq!(report.will_build.len(), 1);
+        assert!(report.will_build.contains("/nix/store/x-foo.drv"));
+    }
+
+    #[test]
+    fn parse_ignores_non_path_indented_lines() {
+        // An indented line that isn't an absolute store path must not pollute
+        // the section — guards against future nix output additions like
+        // "  (note: ...)" inside a section.
+        let stderr = "this derivation will be built:\n  /nix/store/aaa-foo.drv\n  (note: foo)\n";
+        let report = DryRunReport::parse(stderr);
+        assert_eq!(report.will_build.len(), 1);
+    }
+
+    #[test]
+    fn parse_section_resets_on_unrelated_unindented_line() {
+        // Unindented non-blank lines that aren't section headers terminate the
+        // active section so warnings don't get mis-attributed as path entries.
+        let stderr = "this derivation will be built:\n  /nix/store/aaa-foo.drv\nwarning: \
+                      something\n  /nix/store/bbb-bar\n";
+        let report = DryRunReport::parse(stderr);
+        assert_eq!(report.will_build.len(), 1);
+        assert!(report.will_build.contains("/nix/store/aaa-foo.drv"));
+        // The bbb-bar line came after the section was reset, so it's neither.
+        assert!(report.will_fetch.is_empty());
+    }
+
+    #[test]
+    fn parse_blank_line_between_sections() {
+        let stderr = "these 1 derivations will be built:\n  /nix/store/a-foo.drv\n\nthese 1 paths \
+                      will be fetched (1 KiB):\n  /nix/store/b-bar\n";
+        let report = DryRunReport::parse(stderr);
+        assert_eq!(report.will_build.len(), 1);
+        assert_eq!(report.will_fetch.len(), 1);
+    }
+}

--- a/backend/server/src/scheduler/ingress.rs
+++ b/backend/server/src/scheduler/ingress.rs
@@ -5,9 +5,11 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tracing::{debug, warn};
 
+use crate::db::model::build_event::{DrvBuildResult, DrvBuildState};
 use crate::db::model::drv_id;
 use crate::graph::GraphServiceHandle;
 use crate::scheduler::build::BuildRequest;
+use crate::scheduler::recorder::RecorderTask;
 
 /// This acts as the service which filters incoming drv build requests
 /// and determines if the drv is "buildable", already successful,
@@ -22,6 +24,9 @@ pub struct IngressWorker {
     request_receiver: mpsc::Receiver<IngressTask>,
     /// To send buildable requests to builder service
     buildable_sender: mpsc::Sender<BuildRequest>,
+    /// To short-circuit cache hits straight to "successful build" without
+    /// going through the builder thread.
+    recorder_sender: mpsc::Sender<RecorderTask>,
     graph_handle: GraphServiceHandle,
 }
 
@@ -37,6 +42,16 @@ pub enum IngressTask {
     /// a dependency was successfully built, and now we should recheck to
     /// to see if the Drv is now buildable
     CheckBuildable(Arc<drv_id::DrvId>),
+    /// Re-run the substitution check for this drv. Normally fired
+    /// implicitly during `EvalRequest` handling; exposed as a task so
+    /// operators / tests can re-trigger it explicitly (e.g. after a
+    /// remote cache becomes reachable).
+    ///
+    /// Not yet constructed in production code — kept on the public
+    /// task surface for forthcoming admin endpoints. Silence the
+    /// dead-code lint until a caller lands.
+    #[allow(dead_code)]
+    CheckSubstitution(Arc<drv_id::DrvId>),
     /// Rebuild a failed drv by resetting it to Queued and clearing failure tracking
     RebuildFailed(Arc<drv_id::DrvId>),
     /// Rebuild all failed drvs in the system
@@ -55,10 +70,15 @@ impl IngressService {
         (res, request_sender)
     }
 
-    pub fn run(self, buildable_sender: mpsc::Sender<BuildRequest>) -> JoinHandle<()> {
+    pub fn run(
+        self,
+        buildable_sender: mpsc::Sender<BuildRequest>,
+        recorder_sender: mpsc::Sender<RecorderTask>,
+    ) -> JoinHandle<()> {
         let worker = IngressWorker {
             request_receiver: self.request_receiver,
             buildable_sender,
+            recorder_sender,
             graph_handle: self.graph_handle,
         };
         tokio::spawn(async move {
@@ -84,6 +104,17 @@ impl IngressWorker {
         match task {
             EvalRequest(drv) => self.handle_eval_task(drv).await?,
             CheckBuildable(drv) => self.handle_check_buildable_task(drv).await?,
+            CheckSubstitution(drv) => {
+                // Standalone re-check: if cached, short-circuit; otherwise no-op.
+                // Errors here are non-fatal (substitution check is best-effort).
+                if let Err(e) = self.handle_check_substitution_task(drv).await {
+                    warn!(
+                        "substitution check failed for {}: {:?}",
+                        drv.store_path(),
+                        e
+                    );
+                }
+            },
             RebuildFailed(drv) => self.handle_rebuild_failed_task(drv).await?,
             RebuildAllFailed => self.handle_rebuild_all_failed_task().await?,
         }
@@ -94,7 +125,6 @@ impl IngressWorker {
     }
 
     async fn handle_check_buildable_task(&self, drv_id: &drv_id::DrvId) -> anyhow::Result<()> {
-        use crate::db::model::build_event::DrvBuildState;
         debug!("checking if {:?} is buildable", drv_id);
 
         if self.graph_handle.is_buildable(drv_id) {
@@ -132,9 +162,120 @@ impl IngressWorker {
             }
         }
 
+        // Try to short-circuit via substitution before queuing a real build.
+        // A successful cache hit marks this drv (and any cached requisites) as
+        // Completed(Success) via the recorder, which will fan out CheckBuildable
+        // to dependents — no need to fall through.
+        match self.handle_check_substitution_task(drv_id).await {
+            Ok(true) => {
+                debug!("{} short-circuited via substitution", drv_id.store_path());
+                return Ok(());
+            },
+            Ok(false) => { /* not cached; fall through */ },
+            Err(e) => {
+                // Best-effort optimization — log and proceed to build.
+                warn!(
+                    "substitution check errored for {} (falling back to build): {:?}",
+                    drv_id.store_path(),
+                    e
+                );
+            },
+        }
+
         self.handle_check_buildable_task(drv_id).await?;
 
         Ok(())
+    }
+
+    /// Run `nix-store --realise --dry-run` against `drv_id`. If the drv is
+    /// already available (locally or via any configured substituter), mark
+    /// it AND every transitively-cached requisite as `Completed(Success)`
+    /// via the recorder.
+    ///
+    /// Returns `Ok(true)` iff the root drv was a cache hit (and the caller
+    /// should skip queuing a real build).
+    async fn handle_check_substitution_task(&self, drv_id: &drv_id::DrvId) -> anyhow::Result<bool> {
+        let report = crate::nix::dry_run_realise(drv_id).await?;
+
+        // Root must be cached (i.e. NOT in will_build) to short-circuit.
+        if !report.is_cached(drv_id) {
+            return Ok(false);
+        }
+
+        debug!(
+            "substitution hit for {} ({} requisites would be built, {} fetched)",
+            drv_id.store_path(),
+            report.will_build.len(),
+            report.will_fetch.len()
+        );
+
+        // Collect the root + all transitively-cached requisites. We walk
+        // `nix-store --query --requisites` (which returns the root plus all
+        // transitive deps) and keep only the ones NOT marked as
+        // "will be built", since those are the cache hits.
+        let mut cache_hits: Vec<drv_id::DrvId> = Vec::new();
+        match crate::nix::drv_requisites(&drv_id.store_path()).await {
+            Ok(requisites) => {
+                for req in requisites {
+                    if !report.will_build.contains(&req.store_path()) {
+                        cache_hits.push(req);
+                    }
+                }
+            },
+            Err(e) => {
+                // If we can't enumerate requisites, fall back to marking just
+                // the root drv. The dependents-cascade in the recorder will
+                // still correctly re-trigger child evaluation via existing
+                // CheckBuildable flow.
+                warn!(
+                    "failed to enumerate requisites for {} (marking root only): {:?}",
+                    drv_id.store_path(),
+                    e
+                );
+                cache_hits.push(drv_id.clone());
+            },
+        }
+
+        // Always include the root, in case it wasn't returned by --requisites
+        // (defensive — the requisites query normally includes the root, but
+        // we protect against any future behavior change).
+        if !cache_hits.iter().any(|d| d == drv_id) {
+            cache_hits.push(drv_id.clone());
+        }
+
+        // For each cache hit, only emit a recorder task if the current state
+        // is not already terminal AND not currently building. This avoids
+        // racing with an in-flight build or clobbering a previously recorded
+        // success/failure.
+        for hit in cache_hits {
+            let current = self.graph_handle.get_build_state(&hit);
+            let safe_to_mark = match &current {
+                None => true, // not in graph yet; recorder will reject if no DB row
+                Some(DrvBuildState::Building) => false,
+                Some(state) if state.is_terminal() => false,
+                Some(_) => true,
+            };
+            if !safe_to_mark {
+                debug!(
+                    "skipping cache-hit mark for {} (state: {:?})",
+                    hit.store_path(),
+                    current
+                );
+                continue;
+            }
+
+            let task = RecorderTask {
+                derivation: Arc::new(hit),
+                result: DrvBuildState::Completed(DrvBuildResult::Success),
+            };
+            // If recorder is gone we can't make progress; surface the error.
+            self.recorder_sender
+                .send(task)
+                .await
+                .context("recorder channel closed while recording cache hits")?;
+        }
+
+        Ok(true)
     }
 
     /// Rebuild a failed drv by resetting it to Queued and clearing failure tracking.

--- a/backend/server/src/scheduler/service.rs
+++ b/backend/server/src/scheduler/service.rs
@@ -126,7 +126,10 @@ impl SchedulerService {
 
         let (builder_service, builder_sender) =
             BuildQueue::init(builders, fod_builders, build_metrics).await;
-        let ingress_thread = ingress_service.run(builder_sender.clone());
+        // Ingress now needs the recorder channel as well, so it can short-circuit
+        // cache-hit drvs straight to "successful build" without queuing them on
+        // the builder.
+        let ingress_thread = ingress_service.run(builder_sender.clone(), recorder_sender.clone());
         let recorder_thread = recorder_service.run(ingress_sender.clone());
         let builder_thread = builder_service.run();
 

--- a/backend/server/src/secret.rs
+++ b/backend/server/src/secret.rs
@@ -38,6 +38,7 @@ use serde::{Deserialize, Serialize};
 #[serde(transparent)]
 pub struct Redacted<T>(T);
 
+#[allow(dead_code)]
 impl<T> Redacted<T> {
     /// Wrap a value as a redacted secret.
     pub fn new(inner: T) -> Self {


### PR DESCRIPTION
Allow for us to determine if something is already built before building it. Should help withnot having to build every single drv which increases bootstrap time significantly.